### PR TITLE
Use portable C stdint.h for fixed size integer types.

### DIFF
--- a/Test code/Scope_emulator/ScopeEmulator.c
+++ b/Test code/Scope_emulator/ScopeEmulator.c
@@ -226,7 +226,7 @@ int main(int argc,char **argv)
           //Need some scaling algo here to match the scope display to the screen display. The scaling will mostly be one but just in case
           int ix,iy,idx;
 
-          u_int16_t *dptr = (u_int16_t *)&parm_core->dram[parm_core->displaymemory.startaddress].m_16bit[0];
+          uint16_t *dptr = (uint16_t *)&parm_core->dram[parm_core->displaymemory.startaddress].m_16bit[0];
 
           for(iy=0;iy<scopedisplay->height;iy++)
           {

--- a/Test code/Scope_emulator/armv5tl.c
+++ b/Test code/Scope_emulator/armv5tl.c
@@ -319,8 +319,8 @@ void ArmV5tlSetup(PARMV5TL_CORE core)
 
 void ArmV5tlCore(PARMV5TL_CORE core)
 {
-  u_int32_t *memorypointer;
-  u_int32_t  execute = 0;
+  uint32_t  *memorypointer;
+  uint32_t   execute = 0;
   int        i;
   char       tracefilename[64];
   
@@ -454,13 +454,13 @@ void ArmV5tlCore(PARMV5TL_CORE core)
     core->pcincrvalue = 4;
     
     //Instruction fetch for arm state
-    memorypointer = (u_int32_t *)ArmV5tlGetMemoryPointer(core, *core->program_counter, ARM_MEMORY_WORD);
+    memorypointer = (uint32_t *)ArmV5tlGetMemoryPointer(core, *core->program_counter, ARM_MEMORY_WORD);
 
     //Check if a valid address is found
     if(memorypointer)
     {
       //get the current instruction
-      core->arm_instruction.instr = (u_int32_t)*memorypointer;
+      core->arm_instruction.instr = (uint32_t)*memorypointer;
      
       //Check the condition bits against the status bits to decide if the instruction needs to be executed
       switch(core->arm_instruction.base.cond)
@@ -930,7 +930,7 @@ ARMV5TL_ADDRESS_MAP address_map[] =
 
 //----------------------------------------------------------------------------------------------------------------------------------
 
-void *ArmV5tlGetMemoryPointer(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void *ArmV5tlGetMemoryPointer(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   int i;
   
@@ -969,7 +969,7 @@ void *ArmV5tlGetMemoryPointer(PARMV5TL_CORE core, u_int32_t address, u_int32_t m
 
 //----------------------------------------------------------------------------------------------------------------------------------
 
-void ArmV5tlSetMemoryTraceData(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode, u_int32_t count, u_int32_t direction)
+void ArmV5tlSetMemoryTraceData(PARMV5TL_CORE core, uint32_t address, uint32_t mode, uint32_t count, uint32_t direction)
 {
   int i;
   void *memory;
@@ -993,15 +993,15 @@ void ArmV5tlSetMemoryTraceData(PARMV5TL_CORE core, u_int32_t address, u_int32_t 
       switch(mode & ARM_MEMORY_MASK)  
       {
         case ARM_MEMORY_WORD:
-          core->tracebuffer[core->traceindex].data[i] = *(u_int32_t *)memory;
+          core->tracebuffer[core->traceindex].data[i] = *(uint32_t *)memory;
           break;
 
         case ARM_MEMORY_SHORT:
-          core->tracebuffer[core->traceindex].data[i] = *(u_int16_t *)memory;
+          core->tracebuffer[core->traceindex].data[i] = *(uint16_t *)memory;
           break;
 
         case ARM_MEMORY_BYTE:
-          core->tracebuffer[core->traceindex].data[i] = *(u_int8_t *)memory;
+          core->tracebuffer[core->traceindex].data[i] = *(uint8_t *)memory;
           break;
       }
     }
@@ -1034,10 +1034,10 @@ void ArmV5tlUndefinedInstruction(PARMV5TL_CORE core)
 void ArmV5tlDPRShift(PARMV5TL_CORE core)
 {
   //Get the input data
-  u_int32_t vm = *core->registers[core->current_bank][core->arm_instruction.dpsi.rm];
-  u_int32_t vn = *core->registers[core->current_bank][core->arm_instruction.dpsi.rn];
-  u_int32_t sa;
-  u_int32_t c = core->status->flags.C;
+  uint32_t vm = *core->registers[core->current_bank][core->arm_instruction.dpsi.rm];
+  uint32_t vn = *core->registers[core->current_bank][core->arm_instruction.dpsi.rn];
+  uint32_t sa;
+  uint32_t c = core->status->flags.C;
 
   //Amend the values when r15 (pc) is used
   if(core->arm_instruction.dpsi.rn == 15)
@@ -1215,10 +1215,10 @@ void ArmV5tlDPRShift(PARMV5TL_CORE core)
 void ArmV5tlDPRImmediate(PARMV5TL_CORE core)
 {
   //Get the input data
-  u_int32_t vm = core->arm_instruction.dpi.im;
-  u_int32_t vn = *core->registers[core->current_bank][core->arm_instruction.dpsi.rn];
-  u_int32_t ri = core->arm_instruction.dpi.ri << 1;
-  u_int32_t c = core->status->flags.C;
+  uint32_t vm = core->arm_instruction.dpi.im;
+  uint32_t vn = *core->registers[core->current_bank][core->arm_instruction.dpsi.rn];
+  uint32_t ri = core->arm_instruction.dpi.ri << 1;
+  uint32_t c = core->status->flags.C;
   
   //Amend the operand value when r15 (pc) is used
   if(core->arm_instruction.dpsi.rn == 15)
@@ -1242,11 +1242,11 @@ void ArmV5tlDPRImmediate(PARMV5TL_CORE core)
   
 //----------------------------------------------------------------------------------------------------------------------------------
 //Actual data processing handling
-void ArmV5tlDPR(PARMV5TL_CORE core, u_int32_t vn, u_int32_t vm, u_int32_t c)
+void ArmV5tlDPR(PARMV5TL_CORE core, uint32_t vn, uint32_t vm, uint32_t c)
 {
-  u_int64_t vd;
-  u_int32_t update = 1;
-  u_int32_t docandv = ARM_FLAGS_UPDATE_CV_NO;
+  uint64_t vd;
+  uint32_t update = 1;
+  uint32_t docandv = ARM_FLAGS_UPDATE_CV_NO;
   
   //Perform the correct action based on the opcode
   switch(core->arm_instruction.type0.opcode)
@@ -1453,9 +1453,9 @@ void ArmV5tlDPR(PARMV5TL_CORE core, u_int32_t vn, u_int32_t vm, u_int32_t c)
 void ArmV5tlLSImmediate(PARMV5TL_CORE core)
 {
   //Get the input data. Assume target is a word
-  u_int32_t mode = ARM_MEMORY_WORD;
-  u_int32_t vn = *core->registers[core->current_bank][core->arm_instruction.lsi.rn];
-  u_int32_t addr;
+  uint32_t mode = ARM_MEMORY_WORD;
+  uint32_t vn = *core->registers[core->current_bank][core->arm_instruction.lsi.rn];
+  uint32_t addr;
   
   //Amend the value when r15 (pc) is used
   if(core->arm_instruction.lsi.rn == 15)
@@ -1516,11 +1516,11 @@ void ArmV5tlLSImmediate(PARMV5TL_CORE core)
 void ArmV5tlLSRegister(PARMV5TL_CORE core)
 {
   //Get the input data. Assume target is a word
-  u_int32_t mode = ARM_MEMORY_WORD;
-  u_int32_t vm = *core->registers[core->current_bank][core->arm_instruction.lsr.rm];
-  u_int32_t vn = *core->registers[core->current_bank][core->arm_instruction.lsr.rn];
-  u_int32_t addr;
-  u_int32_t sa;
+  uint32_t mode = ARM_MEMORY_WORD;
+  uint32_t vm = *core->registers[core->current_bank][core->arm_instruction.lsr.rm];
+  uint32_t vn = *core->registers[core->current_bank][core->arm_instruction.lsr.rn];
+  uint32_t addr;
+  uint32_t sa;
 
   //Amend the values when r15 (pc) is used
   if(core->arm_instruction.lsr.rn == 15)
@@ -1660,10 +1660,10 @@ void ArmV5tlLSRegister(PARMV5TL_CORE core)
 void ArmV5tlLSExtraImmediate(PARMV5TL_CORE core)
 {
   //The offset is constructed by shifting the high part 4 positions and oring the low part. (rs = immedH, rm = immedL)
-  u_int32_t of = (core->arm_instruction.lsx.rs << 4) | core->arm_instruction.lsx.rm;
-  u_int32_t vn = *core->registers[core->current_bank][core->arm_instruction.lsx.rn];
-  u_int32_t mode = ARM_MEMORY_WORD;
-  u_int32_t addr;
+  uint32_t of = (core->arm_instruction.lsx.rs << 4) | core->arm_instruction.lsx.rm;
+  uint32_t vn = *core->registers[core->current_bank][core->arm_instruction.lsx.rn];
+  uint32_t mode = ARM_MEMORY_WORD;
+  uint32_t addr;
   
   //Amend the value when r15 (pc) is used
   if(core->arm_instruction.lsx.rn == 15)
@@ -1760,10 +1760,10 @@ void ArmV5tlLSExtraImmediate(PARMV5TL_CORE core)
 void ArmV5tlLSExtraRegister(PARMV5TL_CORE core)
 {
   //Get the input data. Assume target is a word
-  u_int32_t mode = ARM_MEMORY_WORD;
-  u_int32_t vm = *core->registers[core->current_bank][core->arm_instruction.lsx.rm];
-  u_int32_t vn = *core->registers[core->current_bank][core->arm_instruction.lsx.rn];
-  u_int32_t addr;
+  uint32_t mode = ARM_MEMORY_WORD;
+  uint32_t vm = *core->registers[core->current_bank][core->arm_instruction.lsx.rm];
+  uint32_t vn = *core->registers[core->current_bank][core->arm_instruction.lsx.rn];
+  uint32_t addr;
 
   //Amend the values when r15 (pc) is used
   if(core->arm_instruction.lsx.rn == 15)
@@ -1863,10 +1863,10 @@ void ArmV5tlLSExtraRegister(PARMV5TL_CORE core)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Load and store instruction handling
-void ArmV5tlLS(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void ArmV5tlLS(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   void *memory;
-  u_int32_t memtype = mode & ARM_MEMORY_MASK;
+  uint32_t memtype = mode & ARM_MEMORY_MASK;
     
   //Get a pointer to the given address based on the mode
   memory = ArmV5tlGetMemoryPointer(core, address, memtype);
@@ -1889,12 +1889,12 @@ void ArmV5tlLS(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
         if(core->arm_instruction.lsr.l)
         {
           //Load from found memory address
-          *core->registers[core->current_bank][core->arm_instruction.lsr.rd] = *(u_int32_t *)memory;
+          *core->registers[core->current_bank][core->arm_instruction.lsr.rd] = *(uint32_t *)memory;
         }
         else
         {
           //Store to found memory address
-          *(u_int32_t *)memory = *core->registers[core->current_bank][core->arm_instruction.lsr.rd];
+          *(uint32_t *)memory = *core->registers[core->current_bank][core->arm_instruction.lsr.rd];
         }
         break;
         
@@ -1903,10 +1903,10 @@ void ArmV5tlLS(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
         if(core->arm_instruction.lsr.l)
         {
           //Load from found memory address
-          *core->registers[core->current_bank][core->arm_instruction.lsr.rd] = *(u_int16_t *)memory;
+          *core->registers[core->current_bank][core->arm_instruction.lsr.rd] = *(uint16_t *)memory;
           
           //Sign extend here when needed
-          if((mode & ARM_SIGN_EXTEND) && (*(u_int16_t *)memory & 0x8000))
+          if((mode & ARM_SIGN_EXTEND) && (*(uint16_t *)memory & 0x8000))
           {
             *core->registers[core->current_bank][core->arm_instruction.lsr.rd] |= 0xFFFF0000;
           }
@@ -1914,7 +1914,7 @@ void ArmV5tlLS(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
         else
         {
           //Store to found memory address
-          *(u_int16_t *)memory = *core->registers[core->current_bank][core->arm_instruction.lsr.rd];
+          *(uint16_t *)memory = *core->registers[core->current_bank][core->arm_instruction.lsr.rd];
         }
         break;
         
@@ -1923,10 +1923,10 @@ void ArmV5tlLS(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
         if(core->arm_instruction.lsr.l)
         {
           //Load from found memory address
-          *core->registers[core->current_bank][core->arm_instruction.lsr.rd] = *(u_int8_t *)memory;
+          *core->registers[core->current_bank][core->arm_instruction.lsr.rd] = *(uint8_t *)memory;
           
           //Sign extend here when needed
-          if((mode & ARM_SIGN_EXTEND) && (*(u_int8_t *)memory & 0x80))
+          if((mode & ARM_SIGN_EXTEND) && (*(uint8_t *)memory & 0x80))
           {
             *core->registers[core->current_bank][core->arm_instruction.lsr.rd] |= 0xFFFFFF00;
           }
@@ -1934,7 +1934,7 @@ void ArmV5tlLS(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
         else
         {
           //Store to found memory address
-          *(u_int8_t *)memory = (u_int8_t)*core->registers[core->current_bank][core->arm_instruction.lsr.rd];
+          *(uint8_t *)memory = (uint8_t)*core->registers[core->current_bank][core->arm_instruction.lsr.rd];
         }
         break;
     }
@@ -1985,11 +1985,11 @@ void ArmV5tlLS(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 //Load and store multiple instruction handling
 void ArmV5tlLSM(PARMV5TL_CORE core)
 {
-  u_int32_t address = *core->registers[core->current_bank][core->arm_instruction.type4.rn];
-  u_int32_t traceaddress;
-  u_int32_t *memory;
-  u_int32_t reglist = core->arm_instruction.instr & 0x0000FFFF;
-  u_int32_t mode = ARM_MEMORY_WORD;
+  uint32_t  address = *core->registers[core->current_bank][core->arm_instruction.type4.rn];
+  uint32_t  traceaddress;
+  uint32_t  *memory;
+  uint32_t  reglist = core->arm_instruction.instr & 0x0000FFFF;
+  uint32_t  mode = ARM_MEMORY_WORD;
   int       numregs = 0;
   int       bank = core->current_bank;
   int       i;
@@ -2237,8 +2237,8 @@ void ArmV5tlLSM(PARMV5TL_CORE core)
 //MUL, MULS, MLA, MLAS, UMULL, UMULLS, UMLAL, UMLALS, SMULL, SMULLS, SMLAL, SMLALS  
 void ArmV5tlMUL(PARMV5TL_CORE core)
 {
-  u_int32_t rm = *core->registers[core->current_bank][core->arm_instruction.mul.rm];
-  u_int32_t rs = *core->registers[core->current_bank][core->arm_instruction.mul.rs];
+  uint32_t rm = *core->registers[core->current_bank][core->arm_instruction.mul.rm];
+  uint32_t rs = *core->registers[core->current_bank][core->arm_instruction.mul.rs];
   int64_t vd;
   int64_t va;
   
@@ -2251,14 +2251,14 @@ void ArmV5tlMUL(PARMV5TL_CORE core)
   else
   {
     //Do multiply with unsigned inputs
-    vd = (u_int64_t)rs * (u_int64_t)rm;
+    vd = (uint64_t)rs * (uint64_t)rm;
   }
   
   //Check if 64 bit accumulate needed (UMLAL op1:5, SMLAL op1:7)
   if((core->arm_instruction.mul.op1 == 5) || (core->arm_instruction.mul.op1 == 7))
   {
     //Get the value to add from the two destination registers. rd holds high part, rn holds low part.
-    va  = (u_int64_t)*core->registers[core->current_bank][core->arm_instruction.mul.rd] << 32;
+    va  = (uint64_t)*core->registers[core->current_bank][core->arm_instruction.mul.rd] << 32;
     va |= *core->registers[core->current_bank][core->arm_instruction.mul.rn];
     
     //Do the summation
@@ -2275,7 +2275,7 @@ void ArmV5tlMUL(PARMV5TL_CORE core)
   if((core->arm_instruction.mul.op1 == 0) || (core->arm_instruction.mul.op1 == 1))
   {
     //Store the 32 bit result back to rd
-    *core->registers[core->current_bank][core->arm_instruction.mul.rd] = (u_int32_t)vd;
+    *core->registers[core->current_bank][core->arm_instruction.mul.rd] = (uint32_t)vd;
     
     //Check if status flags need to be updated
     if(core->arm_instruction.mul.s)
@@ -2291,8 +2291,8 @@ void ArmV5tlMUL(PARMV5TL_CORE core)
   else
   {
     //Store the 64 bit result back to register pair. rd holds high part, rn holds low part.
-    *core->registers[core->current_bank][core->arm_instruction.mul.rd] = (u_int32_t)(vd >> 32);
-    *core->registers[core->current_bank][core->arm_instruction.mul.rn] = (u_int32_t)vd;
+    *core->registers[core->current_bank][core->arm_instruction.mul.rd] = (uint32_t)(vd >> 32);
+    *core->registers[core->current_bank][core->arm_instruction.mul.rn] = (uint32_t)vd;
     
     //Check if status flags need to be updated
     if(core->arm_instruction.mul.s)
@@ -2351,8 +2351,8 @@ void ArmV5tlSMULxy(PARMV5TL_CORE core)
 void ArmV5tlMSRImmediate(PARMV5TL_CORE core)
 {
   //Get the input data
-  u_int32_t vm = core->arm_instruction.msri.im;
-  u_int32_t ri = core->arm_instruction.msri.ri << 1;
+  uint32_t vm = core->arm_instruction.msri.im;
+  uint32_t ri = core->arm_instruction.msri.ri << 1;
   
   //Check if rotation is needed
   if(ri)
@@ -2369,7 +2369,7 @@ void ArmV5tlMSRImmediate(PARMV5TL_CORE core)
 //Move register to status register
 void ArmV5tlMSRRegister(PARMV5TL_CORE core)
 {
-  u_int32_t vm = *core->registers[core->current_bank][core->arm_instruction.msrr.rm];
+  uint32_t vm = *core->registers[core->current_bank][core->arm_instruction.msrr.rm];
   
   //Go and do the actual processing
   ArmV5tlMSR(core, vm);
@@ -2377,9 +2377,9 @@ void ArmV5tlMSRRegister(PARMV5TL_CORE core)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Move to status register
-void ArmV5tlMSR(PARMV5TL_CORE core, u_int32_t data)
+void ArmV5tlMSR(PARMV5TL_CORE core, uint32_t data)
 {
-  u_int32_t bytemask = 0x00000000;
+  uint32_t bytemask = 0x00000000;
   
   //Setup the byte mask based on the field mask bits
   //Control field
@@ -2498,9 +2498,9 @@ void ArmV5tlMRS(PARMV5TL_CORE core)
 //Move register to coprocessor or coprocessor to register
 void ArmV5tlMRCMCR(PARMV5TL_CORE core)
 {
-//  u_int32_t cpn = core->arm_instruction.mrcmcr.cpn;
-//  u_int32_t crm = core->arm_instruction.mrcmcr.crm;
-//  u_int32_t crn = core->arm_instruction.mrcmcr.crn;
+//  uint32_t cpn = core->arm_instruction.mrcmcr.cpn;
+//  uint32_t crm = core->arm_instruction.mrcmcr.crm;
+//  uint32_t crn = core->arm_instruction.mrcmcr.crn;
   
   //For now only coprocessor 15 read is implemented
   if((core->arm_instruction.mrcmcr.cpn == 15) && (core->arm_instruction.mrcmcr.d))
@@ -2570,7 +2570,7 @@ void ArmV5tlBranchLinkExchange1(PARMV5TL_CORE core)
 //Handle branch with link and exchange instructions
 void ArmV5tlBranchLinkExchange2(PARMV5TL_CORE core)
 {
-  u_int32_t address = *core->registers[core->current_bank][core->arm_instruction.misc0.rm];
+  uint32_t address = *core->registers[core->current_bank][core->arm_instruction.misc0.rm];
   
   //Load the address after this instruction to the link register r14
   *core->registers[core->current_bank][14] = *core->program_counter + 4;
@@ -2589,7 +2589,7 @@ void ArmV5tlBranchLinkExchange2(PARMV5TL_CORE core)
 //Handle branch with exchange instructions
 void ArmV5tlBranchExchangeT(PARMV5TL_CORE core)
 {
-  u_int32_t address = *core->registers[core->current_bank][core->arm_instruction.misc0.rm];
+  uint32_t address = *core->registers[core->current_bank][core->arm_instruction.misc0.rm];
   
   //Set the new address. Needs to be on a thumb boundary
   *core->program_counter = address & 0xFFFFFFFE;
@@ -2605,7 +2605,7 @@ void ArmV5tlBranchExchangeT(PARMV5TL_CORE core)
 //Handle branch with exchange instructions
 void ArmV5tlBranchExchangeJ(PARMV5TL_CORE core)
 {
-  u_int32_t address = *core->registers[core->current_bank][core->arm_instruction.misc0.rm];
+  uint32_t address = *core->registers[core->current_bank][core->arm_instruction.misc0.rm];
   
   //This is not correct and needs system info to do the correct things
   
@@ -2624,8 +2624,8 @@ void ArmV5tlBranchExchangeJ(PARMV5TL_CORE core)
 void ArmV5tlCLZ(PARMV5TL_CORE core)
 {
   //Get input data
-  u_int32_t vm = *core->registers[core->current_bank][core->arm_instruction.clz.rm];
-  u_int32_t cnt = 0;
+  uint32_t vm = *core->registers[core->current_bank][core->arm_instruction.clz.rm];
+  uint32_t cnt = 0;
   
   //Check on input being zero
   if(vm == 0)

--- a/Test code/Scope_emulator/armv5tl.h
+++ b/Test code/Scope_emulator/armv5tl.h
@@ -63,19 +63,19 @@ typedef union tagARMV5TL_MEMORY             ARMV5TL_MEMORY;
 
 //----------------------------------------------------------------------------------------------------------------------------------
 
-typedef void *(*PERIPHERALCHECK)(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
+typedef void *(*PERIPHERALCHECK)(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
 
 typedef void (*PERIPHERALFUNC)(PARMV5TL_CORE core);
 
-typedef void (*PERIPHERALREAD)(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-typedef void (*PERIPHERALWRITE)(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
+typedef void (*PERIPHERALREAD)(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+typedef void (*PERIPHERALWRITE)(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
 
 //----------------------------------------------------------------------------------------------------------------------------------
 
 struct tagARMV5TL_ADDRESS_MAP
 {
-  u_int32_t       start;
-  u_int32_t       end;
+  uint32_t       start;
+  uint32_t       end;
   PERIPHERALCHECK function;
   PERIPHERALREAD  read;
   PERIPHERALWRITE write;
@@ -85,402 +85,402 @@ struct tagARMV5TL_ADDRESS_MAP
 
 struct tagARMV5TL_INSTR_BASE
 {
-  u_int32_t data:12;      //Addressing data
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t s:1;          //Update status bit
-  u_int32_t opcode:4;     //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t data:12;      //Addressing data
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t s:1;          //Update status bit
+  uint32_t opcode:4;     //Actual opcode for some type of instructions
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_MUL
 {
-  u_int32_t rm:4;         //Register m
-  u_int32_t nu:4;         //Fixed value
-  u_int32_t rs:4;         //Register s
-  u_int32_t rn:4;         //Register n
-  u_int32_t rd:4;         //Destination register
-  u_int32_t s:1;          //Status update flag
-  u_int32_t op1:3;        //Opcode for type of multiply
-  u_int32_t type:4;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;         //Register m
+  uint32_t nu:4;         //Fixed value
+  uint32_t rs:4;         //Register s
+  uint32_t rn:4;         //Register n
+  uint32_t rd:4;         //Destination register
+  uint32_t s:1;          //Status update flag
+  uint32_t op1:3;        //Opcode for type of multiply
+  uint32_t type:4;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_SMULXY
 {
-  u_int32_t rm:4;         //Register m
-  u_int32_t nu2:1;        //Fixed value
-  u_int32_t x:1;          //mss or lss indicator for rm
-  u_int32_t y:1;          //mss or lss indicator for rs
-  u_int32_t nu1:1;        //Fixed value
-  u_int32_t rs:4;         //Register s
-  u_int32_t rn:4;         //Register n
-  u_int32_t rd:4;         //Destination register
-  u_int32_t s:1;          //Status update flag
-  u_int32_t op1:3;        //Opcode for type of multiply
-  u_int32_t type:4;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;         //Register m
+  uint32_t nu2:1;        //Fixed value
+  uint32_t x:1;          //mss or lss indicator for rm
+  uint32_t y:1;          //mss or lss indicator for rs
+  uint32_t nu1:1;        //Fixed value
+  uint32_t rs:4;         //Register s
+  uint32_t rn:4;         //Register n
+  uint32_t rd:4;         //Destination register
+  uint32_t s:1;          //Status update flag
+  uint32_t op1:3;        //Opcode for type of multiply
+  uint32_t type:4;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_ELS
 {
-  u_int32_t rm:4;         //Register
-  u_int32_t nu1:1;        //Always one
-  u_int32_t opcode:2;     //Opcode
-  u_int32_t nu2:1;        //Always one
-  u_int32_t rs:4;         //Register
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t l:1;          //
-  u_int32_t w:1;          //
-  u_int32_t b:1;          //
-  u_int32_t u:1;          //
-  u_int32_t p:1;          //
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;         //Register
+  uint32_t nu1:1;        //Always one
+  uint32_t opcode:2;     //Opcode
+  uint32_t nu2:1;        //Always one
+  uint32_t rs:4;         //Register
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t l:1;          //
+  uint32_t w:1;          //
+  uint32_t b:1;          //
+  uint32_t u:1;          //
+  uint32_t p:1;          //
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_LSI
 {
-  u_int32_t of:12;        //Offset
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t l:1;          //Load or store. 1: Load. 0: Store.
-  u_int32_t w:1;          //For offset addressing this is the write back to base indicator.
-  u_int32_t b:1;          //Unsigned byte mode
-  u_int32_t u:1;          //Offset use mode 1: Add to base. 0: Subtract from base
-  u_int32_t p:1;          //Pre indexed addressing. Combined with W bit
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t of:12;        //Offset
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t l:1;          //Load or store. 1: Load. 0: Store.
+  uint32_t w:1;          //For offset addressing this is the write back to base indicator.
+  uint32_t b:1;          //Unsigned byte mode
+  uint32_t u:1;          //Offset use mode 1: Add to base. 0: Subtract from base
+  uint32_t p:1;          //Pre indexed addressing. Combined with W bit
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_LSR
 {
-  u_int32_t rm:4;        //Offset
-  u_int32_t nu:1;         //Not used
-  u_int32_t sm:2;         //Shift mode
-  u_int32_t sa:5;         //Shift amount
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t l:1;          //Load or store. 1: Load. 0: Store.
-  u_int32_t w:1;          //For offset addressing this is the write back to base indicator.
-  u_int32_t b:1;          //Unsigned byte mode
-  u_int32_t u:1;          //Offset use mode 1: Add to base. 0: Subtract from base
-  u_int32_t p:1;          //Pre indexed addressing. Combined with W bit
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;        //Offset
+  uint32_t nu:1;         //Not used
+  uint32_t sm:2;         //Shift mode
+  uint32_t sa:5;         //Shift amount
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t l:1;          //Load or store. 1: Load. 0: Store.
+  uint32_t w:1;          //For offset addressing this is the write back to base indicator.
+  uint32_t b:1;          //Unsigned byte mode
+  uint32_t u:1;          //Offset use mode 1: Add to base. 0: Subtract from base
+  uint32_t p:1;          //Pre indexed addressing. Combined with W bit
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_LSRN
 {
-  u_int32_t rm:4;         //Register m
-  u_int32_t ns:8;         //No scaling when zero
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t l:1;          //Load or store. 1: Load. 0: Store.
-  u_int32_t w:1;          //For offset addressing this is the write back to base indicator.
-  u_int32_t b:1;          //Unsigned byte mode
-  u_int32_t u:1;          //Offset use mode 1: Add to base. 0: Subtract from base
-  u_int32_t p:1;          //Pre indexed addressing. Combined with W bit
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;         //Register m
+  uint32_t ns:8;         //No scaling when zero
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t l:1;          //Load or store. 1: Load. 0: Store.
+  uint32_t w:1;          //For offset addressing this is the write back to base indicator.
+  uint32_t b:1;          //Unsigned byte mode
+  uint32_t u:1;          //Offset use mode 1: Add to base. 0: Subtract from base
+  uint32_t p:1;          //Pre indexed addressing. Combined with W bit
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_LSX
 {
-  u_int32_t rm:4;         //Register m
-  u_int32_t sbo2:1;       //Should be one
-  u_int32_t op1:2;        //Extra opcode
-  u_int32_t sbo1:1;       //Should be one
-  u_int32_t rs:4;         //Register s
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Register n
-  u_int32_t l:1;          //Load or store. 1: Load. 0: Store.
-  u_int32_t w:1;          //For offset addressing this is the write back to base indicator.
-  u_int32_t i:1;          //Immediate offset / index or register offset / index
-  u_int32_t u:1;          //Offset use mode 1: Add to base. 0: Subtract from base
-  u_int32_t p:1;          //Pre indexed addressing. Combined with W bit
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;         //Register m
+  uint32_t sbo2:1;       //Should be one
+  uint32_t op1:2;        //Extra opcode
+  uint32_t sbo1:1;       //Should be one
+  uint32_t rs:4;         //Register s
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Register n
+  uint32_t l:1;          //Load or store. 1: Load. 0: Store.
+  uint32_t w:1;          //For offset addressing this is the write back to base indicator.
+  uint32_t i:1;          //Immediate offset / index or register offset / index
+  uint32_t u:1;          //Offset use mode 1: Add to base. 0: Subtract from base
+  uint32_t p:1;          //Pre indexed addressing. Combined with W bit
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_DPSI
 {
-  u_int32_t rm:4;         //Register
-  u_int32_t t1:1;         //Shift type
-  u_int32_t sm:2;         //Shift mode
-  u_int32_t sa:5;         //Shift amount
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t opcode:4;     //Opcode for type of multiply
-  u_int32_t type:4;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;         //Register
+  uint32_t t1:1;         //Shift type
+  uint32_t sm:2;         //Shift mode
+  uint32_t sa:5;         //Shift amount
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t opcode:4;     //Opcode for type of multiply
+  uint32_t type:4;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_DPSR
 {
-  u_int32_t rm:4;         //Register
-  u_int32_t t1:1;         //Shift type
-  u_int32_t sm:2;         //Shift mode
-  u_int32_t nu:1;         //Always 0
-  u_int32_t rs:4;         //Shift amount register
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t opcode:4;     //Opcode for type of data processing
-  u_int32_t type:4;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;         //Register
+  uint32_t t1:1;         //Shift type
+  uint32_t sm:2;         //Shift mode
+  uint32_t nu:1;         //Always 0
+  uint32_t rs:4;         //Shift amount register
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t opcode:4;     //Opcode for type of data processing
+  uint32_t type:4;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_DPI
 {
-  u_int32_t im:8;         //Immediate value
-  u_int32_t ri:4;         //Rotate immediate
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t opcode:4;     //Opcode for type of data processing
-  u_int32_t type:4;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t im:8;         //Immediate value
+  uint32_t ri:4;         //Rotate immediate
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t opcode:4;     //Opcode for type of data processing
+  uint32_t type:4;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_MSRI
 {
-  u_int32_t im:8;         //Immediate value
-  u_int32_t ri:4;         //Rotate immediate
-  u_int32_t sbo:4;        //Should be one
-  u_int32_t c:1;          //Control field mask
-  u_int32_t x:1;          //Extension field mask
-  u_int32_t s:1;          //Status field mask
-  u_int32_t f:1;          //Flags field mask
-  u_int32_t nu1:2;        //Not used after decoding
-  u_int32_t r:1;          //Target register select 0: cpsr. 1: spsr.
-  u_int32_t nu2:5;        //Not used after decoding
-  u_int32_t cond:4;       //Condition bits
+  uint32_t im:8;         //Immediate value
+  uint32_t ri:4;         //Rotate immediate
+  uint32_t sbo:4;        //Should be one
+  uint32_t c:1;          //Control field mask
+  uint32_t x:1;          //Extension field mask
+  uint32_t s:1;          //Status field mask
+  uint32_t f:1;          //Flags field mask
+  uint32_t nu1:2;        //Not used after decoding
+  uint32_t r:1;          //Target register select 0: cpsr. 1: spsr.
+  uint32_t nu2:5;        //Not used after decoding
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_MSRR
 {
-  u_int32_t rm:4;         //Register holding the data
-  u_int32_t sbz:8;        //Should be zero
-  u_int32_t sbo:4;        //Should be one
-  u_int32_t c:1;          //Control field mask
-  u_int32_t x:1;          //Extension field mask
-  u_int32_t s:1;          //Status field mask
-  u_int32_t f:1;          //Flags field mask
-  u_int32_t nu1:1;        //Not used after decoding
-  u_int32_t d:1;          //Move direction bit
-  u_int32_t r:1;          //Target register select 0: cpsr. 1: spsr.
-  u_int32_t nu2:5;        //Not used after decoding
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;         //Register holding the data
+  uint32_t sbz:8;        //Should be zero
+  uint32_t sbo:4;        //Should be one
+  uint32_t c:1;          //Control field mask
+  uint32_t x:1;          //Extension field mask
+  uint32_t s:1;          //Status field mask
+  uint32_t f:1;          //Flags field mask
+  uint32_t nu1:1;        //Not used after decoding
+  uint32_t d:1;          //Move direction bit
+  uint32_t r:1;          //Target register select 0: cpsr. 1: spsr.
+  uint32_t nu2:5;        //Not used after decoding
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_MRS
 {
-  u_int32_t sbz:12;       //Should be zero
-  u_int32_t rd:4;         //Destination register
-  u_int32_t sbo:4;        //Should be one
-  u_int32_t nu1:2;        //Not used after decoding
-  u_int32_t r:1;          //Source register select 0: cpsr. 1: spsr.
-  u_int32_t nu2:5;        //Not used after decoding
-  u_int32_t cond:4;       //Condition bits
+  uint32_t sbz:12;       //Should be zero
+  uint32_t rd:4;         //Destination register
+  uint32_t sbo:4;        //Should be one
+  uint32_t nu1:2;        //Not used after decoding
+  uint32_t r:1;          //Source register select 0: cpsr. 1: spsr.
+  uint32_t nu2:5;        //Not used after decoding
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_MRCMCR
 {
-  u_int32_t crm:4;        //Coprocessor register m
-  u_int32_t nu:1;         //Not used after decoding
-  u_int32_t op2:3;        //Coprocessor opcode 2
-  u_int32_t cpn:4;        //Coprocessor number
-  u_int32_t rd:4;         //Destination register
-  u_int32_t crn:4;        //Coprocessor register n
-  u_int32_t d:1;          //Data direction bit
-  u_int32_t op1:3;        //Coprocessor opcode 1
-  u_int32_t type:4;       //Type bits
-  u_int32_t cond:4;       //Condition bits
+  uint32_t crm:4;        //Coprocessor register m
+  uint32_t nu:1;         //Not used after decoding
+  uint32_t op2:3;        //Coprocessor opcode 2
+  uint32_t cpn:4;        //Coprocessor number
+  uint32_t rd:4;         //Destination register
+  uint32_t crn:4;        //Coprocessor register n
+  uint32_t d:1;          //Data direction bit
+  uint32_t op1:3;        //Coprocessor opcode 1
+  uint32_t type:4;       //Type bits
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_MISC0
 {
-  u_int32_t rm:4;         //Register
-  u_int32_t op2:4;        //Opcode 2
-  u_int32_t rs:4;         //Multiply register
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t s:1;          //Update status bit
-  u_int32_t op1:2;        //Opcode 1
-  u_int32_t type:5;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;         //Register
+  uint32_t op2:4;        //Opcode 2
+  uint32_t rs:4;         //Multiply register
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t s:1;          //Update status bit
+  uint32_t op1:2;        //Opcode 1
+  uint32_t type:5;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_CLZ
 {
-  u_int32_t rm:4;         //Register
-  u_int32_t nu2:4;        //Not used
-  u_int32_t sbo:4;        //Should be one
-  u_int32_t rd:4;         //Destination register
-  u_int32_t nu1:12;       //Not used
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;         //Register
+  uint32_t nu2:4;        //Not used
+  uint32_t sbo:4;        //Should be one
+  uint32_t rd:4;         //Destination register
+  uint32_t nu1:12;       //Not used
+  uint32_t cond:4;       //Condition bits
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
 
 struct tagARMV5TL_INSTR_TYPE0
 {
-  u_int32_t rm:4;         //Register
-  u_int32_t it1:1;        //Instruction type
-  u_int32_t sm:2;         //Shift mode
-  u_int32_t it2:1;        //Instruction type
-  u_int32_t rs:4;         //Register
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t s:1;          //Update status bit
-  u_int32_t opcode:4;     //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;         //Register
+  uint32_t it1:1;        //Instruction type
+  uint32_t sm:2;         //Shift mode
+  uint32_t it2:1;        //Instruction type
+  uint32_t rs:4;         //Register
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t s:1;          //Update status bit
+  uint32_t opcode:4;     //Actual opcode for some type of instructions
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_TYPE1
 {
-  u_int32_t im:8;         //Immediate
-  u_int32_t r:4;          //Rotate
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t s:1;          //Update status bit
-  u_int32_t opcode:4;     //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t im:8;         //Immediate
+  uint32_t r:4;          //Rotate
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t s:1;          //Update status bit
+  uint32_t opcode:4;     //Actual opcode for some type of instructions
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_TYPE2
 {
-  u_int32_t im:12;        //Immediate data
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t l:1;          //Load or store. 1: Load. 0: Store.
-  u_int32_t w:1;          //For offset addressing this is the write back to base indicator.
-  u_int32_t b:1;          //Unsigned byte mode
-  u_int32_t u:1;          //Offset use mode 1: Add to base. 0: Subtract from base
-  u_int32_t p:1;          //Pre indexed addressing. Combined with W bit
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t im:12;        //Immediate data
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t l:1;          //Load or store. 1: Load. 0: Store.
+  uint32_t w:1;          //For offset addressing this is the write back to base indicator.
+  uint32_t b:1;          //Unsigned byte mode
+  uint32_t u:1;          //Offset use mode 1: Add to base. 0: Subtract from base
+  uint32_t p:1;          //Pre indexed addressing. Combined with W bit
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_TYPE3
 {
-  u_int32_t rm:4;         //Register
-  u_int32_t it1:1;        //Instruction type
-  u_int32_t sm:2;         //Shift mode
-  u_int32_t sa:5;         //Shift amount
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t l:1;          //Load or store. 1: Load. 0: Store.
-  u_int32_t w:1;          //For offset addressing this is the write back to base indicator.
-  u_int32_t b:1;          //Unsigned byte mode
-  u_int32_t u:1;          //Offset use mode 1: Add to base. 0: Subtract from base
-  u_int32_t p:1;          //Pre indexed addressing. Combined with W bit
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;         //Register
+  uint32_t it1:1;        //Instruction type
+  uint32_t sm:2;         //Shift mode
+  uint32_t sa:5;         //Shift amount
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t l:1;          //Load or store. 1: Load. 0: Store.
+  uint32_t w:1;          //For offset addressing this is the write back to base indicator.
+  uint32_t b:1;          //Unsigned byte mode
+  uint32_t u:1;          //Offset use mode 1: Add to base. 0: Subtract from base
+  uint32_t p:1;          //Pre indexed addressing. Combined with W bit
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_TYPE4
 {
-  u_int32_t r0:1;         //Include r0
-  u_int32_t r1:1;         //Include r1
-  u_int32_t r2:1;         //Include r2
-  u_int32_t r3:1;         //Include r3
-  u_int32_t r4:1;         //Include r4
-  u_int32_t r5:1;         //Include r5
-  u_int32_t r6:1;         //Include r6
-  u_int32_t r7:1;         //Include r7
-  u_int32_t r8:1;         //Include r8
-  u_int32_t r9:1;         //Include r9
-  u_int32_t r10:1;        //Include r10
-  u_int32_t r11:1;        //Include r11
-  u_int32_t r12:1;        //Include r12
-  u_int32_t r13:1;        //Include r13
-  u_int32_t r14:1;        //Include r14
-  u_int32_t r15:1;        //Include r15
-  u_int32_t rn:4;         //Register holding the base address
-  u_int32_t l:1;          //Load or store. 1: Load. 0: Store.
-  u_int32_t w:1;          //Update base register after transfer
-  u_int32_t s:1;          //Restore cpsr from spsr when r15 included
-  u_int32_t u:1;          //Direction. 1: Add to base. 0: Subtract from base
-  u_int32_t p:1;          //Range base included or not
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t r0:1;         //Include r0
+  uint32_t r1:1;         //Include r1
+  uint32_t r2:1;         //Include r2
+  uint32_t r3:1;         //Include r3
+  uint32_t r4:1;         //Include r4
+  uint32_t r5:1;         //Include r5
+  uint32_t r6:1;         //Include r6
+  uint32_t r7:1;         //Include r7
+  uint32_t r8:1;         //Include r8
+  uint32_t r9:1;         //Include r9
+  uint32_t r10:1;        //Include r10
+  uint32_t r11:1;        //Include r11
+  uint32_t r12:1;        //Include r12
+  uint32_t r13:1;        //Include r13
+  uint32_t r14:1;        //Include r14
+  uint32_t r15:1;        //Include r15
+  uint32_t rn:4;         //Register holding the base address
+  uint32_t l:1;          //Load or store. 1: Load. 0: Store.
+  uint32_t w:1;          //Update base register after transfer
+  uint32_t s:1;          //Restore cpsr from spsr when r15 included
+  uint32_t u:1;          //Direction. 1: Add to base. 0: Subtract from base
+  uint32_t p:1;          //Range base included or not
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_TYPE5
 {
-  u_int32_t offset:24;    //Signed offset
-  u_int32_t l:1;          //Update link register
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t offset:24;    //Signed offset
+  uint32_t l:1;          //Update link register
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_TYPE6
 {
-  u_int32_t of:8;         //Offset
-  u_int32_t cp:4;         //Coprocessor number
-  u_int32_t crd:4;        //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t l:1;          //
-  u_int32_t w:1;          //
-  u_int32_t n:1;          //
-  u_int32_t u:1;          //
-  u_int32_t p:1;          //
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t of:8;         //Offset
+  uint32_t cp:4;         //Coprocessor number
+  uint32_t crd:4;        //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t l:1;          //
+  uint32_t w:1;          //
+  uint32_t n:1;          //
+  uint32_t u:1;          //
+  uint32_t p:1;          //
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 struct tagARMV5TL_INSTR_TYPE7
 {
-  u_int32_t rm:4;         //Register
-  u_int32_t it1:1;        //Type of instruction bit
-  u_int32_t sm:2;         //Shift mode
-  u_int32_t sa:5;         //Shift amount
-  u_int32_t rd:4;         //Destination register
-  u_int32_t rn:4;         //Second operand register
-  u_int32_t l:1;          //
-  u_int32_t w:1;          //
-  u_int32_t b:1;          //
-  u_int32_t u:1;          //
-  u_int32_t it2:1;        //Type of instruction bit
-  u_int32_t type:3;       //Type of instructions
-  u_int32_t cond:4;       //Condition bits
+  uint32_t rm:4;         //Register
+  uint32_t it1:1;        //Type of instruction bit
+  uint32_t sm:2;         //Shift mode
+  uint32_t sa:5;         //Shift amount
+  uint32_t rd:4;         //Destination register
+  uint32_t rn:4;         //Second operand register
+  uint32_t l:1;          //
+  uint32_t w:1;          //
+  uint32_t b:1;          //
+  uint32_t u:1;          //
+  uint32_t it2:1;        //Type of instruction bit
+  uint32_t type:3;       //Type of instructions
+  uint32_t cond:4;       //Condition bits
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
 
 struct tagARMV5TL_FLAGS
 {
-  u_int32_t M:5;         //Mode bits
-  u_int32_t T:1;         //Thumb execution state flag
-  u_int32_t F:1;         //Fast Interrupt disable flag
-  u_int32_t I:1;         //Interrupt disable flag
-  u_int32_t R1:8;        //Reserved bits
-  u_int32_t GE:4;        //Greater then or equal flags
-  u_int32_t R2:4;        //Reserved bits
-  u_int32_t J:1;         //Jazelle execution state flag
-  u_int32_t R3:2;        //Reserved bits
-  u_int32_t Q:1;         //DSP overflow / saturation flag
-  u_int32_t V:1;         //Overflow flag
-  u_int32_t C:1;         //Carry flag
-  u_int32_t Z:1;         //Zero flag
-  u_int32_t N:1;         //Negative flag
+  uint32_t M:5;         //Mode bits
+  uint32_t T:1;         //Thumb execution state flag
+  uint32_t F:1;         //Fast Interrupt disable flag
+  uint32_t I:1;         //Interrupt disable flag
+  uint32_t R1:8;        //Reserved bits
+  uint32_t GE:4;        //Greater then or equal flags
+  uint32_t R2:4;        //Reserved bits
+  uint32_t J:1;         //Jazelle execution state flag
+  uint32_t R3:2;        //Reserved bits
+  uint32_t Q:1;         //DSP overflow / saturation flag
+  uint32_t V:1;         //Overflow flag
+  uint32_t C:1;         //Carry flag
+  uint32_t Z:1;         //Zero flag
+  uint32_t N:1;         //Negative flag
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
 
 union tagARMV5TL_STATUS
 {
-  u_int32_t     word;            //Word register
-  ARMV5TL_FLAGS flags;           //Bit flags
+  uint32_t     word;            //Word register
+  ARMV5TL_FLAGS flags;          //Bit flags
 };                                        
 
 union tagARMV5TL_ARM_INSTRUCTION
 {
-  u_int32_t                instr;      //Instruction register
+  uint32_t                instr;       //Instruction register
   ARMV5TL_INSTR_BASE       base;       //Base for instruction decoding
   ARMV5TL_INSTR_MISC0      misc0;      //Miscellaneous instructions
   ARMV5TL_INSTR_TYPE0      type0;      //For type 0 instruction decoding
@@ -510,75 +510,75 @@ union tagARMV5TL_ARM_INSTRUCTION
 
 union tagARMV5TL_MEMORY
 {
-  u_int32_t  m_32bit;
-  u_int16_t  m_16bit[2];
-  u_int8_t   m_8bit[4];
+  uint32_t  m_32bit;
+  uint16_t  m_16bit[2];
+  uint8_t   m_8bit[4];
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //The complete arm register set
 struct tagARMV5TL_REGS
 {
-  u_int32_t r0;
-  u_int32_t r1;
-  u_int32_t r2;
-  u_int32_t r3;
-  u_int32_t r4;
-  u_int32_t r5;
-  u_int32_t r6;
-  u_int32_t r7;
-  u_int32_t r8[2];
-  u_int32_t r9[2];
-  u_int32_t r10[2];
-  u_int32_t r11[2];
-  u_int32_t r12[2];
-  u_int32_t r13[6];
-  u_int32_t r14[6];
-  u_int32_t r15;
-  u_int32_t cpsr;
-  u_int32_t spsr[5];
+  uint32_t r0;
+  uint32_t r1;
+  uint32_t r2;
+  uint32_t r3;
+  uint32_t r4;
+  uint32_t r5;
+  uint32_t r6;
+  uint32_t r7;
+  uint32_t r8[2];
+  uint32_t r9[2];
+  uint32_t r10[2];
+  uint32_t r11[2];
+  uint32_t r12[2];
+  uint32_t r13[6];
+  uint32_t r14[6];
+  uint32_t r15;
+  uint32_t cpsr;
+  uint32_t spsr[5];
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
 
 struct tagARMV5TL_TRACE_ENTRY
 {
-  u_int32_t    instruction_address;    //Address of the traced instruction
-  u_int32_t    instruction_word;       //Instruction word for arm, half word for thumb
-  u_int32_t    execution_status;       //Information about if the arm instruction has been executed or not
+  uint32_t    instruction_address;     //Address of the traced instruction
+  uint32_t    instruction_word;        //Instruction word for arm, half word for thumb
+  uint32_t    execution_status;        //Information about if the arm instruction has been executed or not
   ARMV5TL_REGS registers;              //The 37 registers
-  u_int32_t    memory_address;         //Depending on the type of instruction this is set with the targeted memory address
-  u_int32_t    memory_direction;       //For load or store multiple instructions this signals if the given address is incremented or decremented
-  u_int32_t    data_width;             //For instructions that load or store half words or bytes this will reflect this, otherwise word width
-  u_int32_t    data_count;             //The number of words read or written by the instruction
-  u_int32_t    data[16];               //The data read or written. Single instruction can do a max of 16 words
+  uint32_t    memory_address;          //Depending on the type of instruction this is set with the targeted memory address
+  uint32_t    memory_direction;        //For load or store multiple instructions this signals if the given address is incremented or decremented
+  uint32_t    data_width;              //For instructions that load or store half words or bytes this will reflect this, otherwise word width
+  uint32_t    data_count;              //The number of words read or written by the instruction
+  uint32_t    data[16];                //The data read or written. Single instruction can do a max of 16 words
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //The core main struct
 struct tagARMV5TL_CORE
 {
-  u_int32_t                *registers[6][18];         //The ARM core has banked register sets. In different modes some of the registers are not available or are the un_banked user mode ones. Pointers are used to emulate this.
+  uint32_t                *registers[6][18];          //The ARM core has banked register sets. In different modes some of the registers are not available or are the un_banked user mode ones. Pointers are used to emulate this.
   
-  u_int32_t                 current_mode;             //The mode the core is running in.
-  u_int32_t                 current_bank;             //The register bank currently in use.
+  uint32_t                 current_mode;              //The mode the core is running in.
+  uint32_t                 current_bank;              //The register bank currently in use.
   
   ARMV5TL_ARM_INSTRUCTION   arm_instruction;          //The arm instruction loaded for the current cycle. Only when in arm state
   ARMV5TL_THUMB_INSTRUCTION thumb_instruction;        //The thumb instruction loaded for the current cycle. Only when in thumb state
   
-  u_int32_t                 pcincrvalue;              //Value the program counter needs to be incremented with
+  uint32_t                 pcincrvalue;               //Value the program counter needs to be incremented with
   
-  u_int64_t                 cpu_cycles;               //Counter for counting the cpu instruction cycles. Used for timing peripherals
+  uint64_t                 cpu_cycles;                //Counter for counting the cpu instruction cycles. Used for timing peripherals
   
   int                      *program_counter;          //For more direct control a pointer to the program counter here
   ARMV5TL_STATUS           *status;                   //Same for the status word
   
-  u_int32_t                 reset;                    //Processor reset flag
-  u_int32_t                 irq;                      //Processor irg flag
-  u_int32_t                 fiq;                      //Processor fast interrupt flag
-  u_int32_t                 undefinedinstruction;     //Flag to signal undefined instruction encountered
+  uint32_t                 reset;                     //Processor reset flag
+  uint32_t                 irq;                       //Processor irg flag
+  uint32_t                 fiq;                       //Processor fast interrupt flag
+  uint32_t                 undefinedinstruction;      //Flag to signal undefined instruction encountered
   
-  u_int32_t                 run;                      //Processor run flag
+  uint32_t                 run;                       //Processor run flag
   
   ARMV5TL_MEMORY            sram1[8192];              //32K core startup memory located at address 0x00000000
   ARMV5TL_MEMORY            sram2[10240];             //40K core static memory located at address 0x00010000
@@ -624,14 +624,14 @@ struct tagARMV5TL_CORE
   //Debug and tracing support
   FILE                     *TraceFilePointer;         //Null if tracing is disabled
   
-  u_int32_t                 breakpointaddress;        //Instruction address for breakpoint
+  uint32_t                 breakpointaddress;         //Instruction address for breakpoint
   
-  u_int32_t                 tracetriggeraddress;      //Instruction address to start tracing on
-  u_int32_t                 tracetriggered;           //Flag to signal tracing has been triggered
-  u_int32_t                 tracecount;               //Counter for limiting trace files to 256K Lines
-  u_int32_t                 tracefileindex;           //Index counter for the trace file name
-  u_int32_t                 tracebufferenabled;       //Flag to signal writing into the trace buffer is enabled
-  u_int32_t                 traceindex;               //Index into the trace buffer
+  uint32_t                 tracetriggeraddress;       //Instruction address to start tracing on
+  uint32_t                 tracetriggered;            //Flag to signal tracing has been triggered
+  uint32_t                 tracecount;                //Counter for limiting trace files to 256K Lines
+  uint32_t                 tracefileindex;            //Index counter for the trace file name
+  uint32_t                 tracebufferenabled;        //Flag to signal writing into the trace buffer is enabled
+  uint32_t                 traceindex;                //Index into the trace buffer
   ARMV5TL_TRACE_ENTRY       tracebuffer[4096];        //A trace buffer to be able to get pre trace trigger info
 };
 
@@ -750,11 +750,11 @@ void ArmV5tlCore(PARMV5TL_CORE core);
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //General memory handler
-void *ArmV5tlGetMemoryPointer(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
+void *ArmV5tlGetMemoryPointer(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
 
 //----------------------------------------------------------------------------------------------------------------------------------
 
-void ArmV5tlSetMemoryTraceData(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode, u_int32_t count, u_int32_t direction);
+void ArmV5tlSetMemoryTraceData(PARMV5TL_CORE core, uint32_t address, uint32_t mode, uint32_t count, uint32_t direction);
 
 //----------------------------------------------------------------------------------------------------------------------------------
 
@@ -768,7 +768,7 @@ void ArmV5tlDPRShift(PARMV5TL_CORE core);
 void ArmV5tlDPRImmediate(PARMV5TL_CORE core);
 
 //Data processing instruction handling
-void ArmV5tlDPR(PARMV5TL_CORE core, u_int32_t vn, u_int32_t vm, u_int32_t c);
+void ArmV5tlDPR(PARMV5TL_CORE core, uint32_t vn, uint32_t vm, uint32_t c);
 
 //Load and store immediate instruction handling
 void ArmV5tlLSImmediate(PARMV5TL_CORE core);
@@ -783,7 +783,7 @@ void ArmV5tlLSExtraImmediate(PARMV5TL_CORE core);
 void ArmV5tlLSExtraRegister(PARMV5TL_CORE core);
 
 //Load and store instruction handling
-void ArmV5tlLS(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
+void ArmV5tlLS(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
 
 //Load and store multiple instruction handling
 void ArmV5tlLSM(PARMV5TL_CORE core);
@@ -799,7 +799,7 @@ void ArmV5tlMSRImmediate(PARMV5TL_CORE core);
 void ArmV5tlMSRRegister(PARMV5TL_CORE core);
 
 //Move to status register
-void ArmV5tlMSR(PARMV5TL_CORE core, u_int32_t data);
+void ArmV5tlMSR(PARMV5TL_CORE core, uint32_t data);
 
 //Move status register to register
 void ArmV5tlMRS(PARMV5TL_CORE core);

--- a/Test code/Scope_emulator/armv5tl_thumb.c
+++ b/Test code/Scope_emulator/armv5tl_thumb.c
@@ -10,16 +10,16 @@
 
 void ArmV5tlHandleThumb(PARMV5TL_CORE core)
 {
-  u_int16_t *memorypointer;
+  uint16_t *memorypointer;
 
   //Instruction fetch for thumb state
-  memorypointer = (u_int16_t *)ArmV5tlGetMemoryPointer(core, *core->program_counter, ARM_MEMORY_SHORT);
+  memorypointer = (uint16_t *)ArmV5tlGetMemoryPointer(core, *core->program_counter, ARM_MEMORY_SHORT);
 
   //Check if a valid address is found
   if(memorypointer)
   {
     //get the current instruction
-    core->thumb_instruction.instr = (u_int16_t)*memorypointer;
+    core->thumb_instruction.instr = (uint16_t)*memorypointer;
     
     //Check if tracing into buffer is enabled.
     if(core->tracebufferenabled)
@@ -222,9 +222,9 @@ void ArmV5tlHandleThumb(PARMV5TL_CORE core)
 //Immediate shift
 void ArmV5tlThumbShiftImmediate(PARMV5TL_CORE core)
 {
-  u_int32_t sa = core->thumb_instruction.shift0.sa;
-  u_int32_t vm = *core->registers[core->current_bank][core->thumb_instruction.shift0.rm];
-  u_int32_t type;
+  uint32_t sa = core->thumb_instruction.shift0.sa;
+  uint32_t vm = *core->registers[core->current_bank][core->thumb_instruction.shift0.rm];
+  uint32_t type;
   
   
   switch(core->thumb_instruction.shift0.op1)
@@ -258,9 +258,9 @@ void ArmV5tlThumbShiftImmediate(PARMV5TL_CORE core)
 //Register shift
 void ArmV5tlThumbShiftRegister(PARMV5TL_CORE core)
 {
-  u_int32_t sa = *core->registers[core->current_bank][core->thumb_instruction.shift2.rs];
-  u_int32_t vm = *core->registers[core->current_bank][core->thumb_instruction.shift2.rd];
-  u_int32_t type;
+  uint32_t sa = *core->registers[core->current_bank][core->thumb_instruction.shift2.rs];
+  uint32_t vm = *core->registers[core->current_bank][core->thumb_instruction.shift2.rd];
+  uint32_t type;
   
   //LSL(2) op2:2, LSR(2) op2:3, ASR(2) op2:4, ROR op2:7
   //Other values are filtered out in the decode stage
@@ -289,9 +289,9 @@ void ArmV5tlThumbShiftRegister(PARMV5TL_CORE core)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Shift
-void ArmV5tlThumbShift(PARMV5TL_CORE core, u_int32_t type, u_int32_t sa, u_int32_t vm)
+void ArmV5tlThumbShift(PARMV5TL_CORE core, uint32_t type, uint32_t sa, uint32_t vm)
 {
-  u_int32_t c = core->status->flags.C;
+  uint32_t c = core->status->flags.C;
   
   //Take action based on the shift type
   switch(type)
@@ -410,10 +410,10 @@ void ArmV5tlThumbShift(PARMV5TL_CORE core, u_int32_t type, u_int32_t sa, u_int32
 void ArmV5tlThumbDP0(PARMV5TL_CORE core)
 {
   //Get the input data. For rd and vn there is no difference between dpi0 and dpr0
-  u_int32_t rd = core->thumb_instruction.dpi0.rd;
-  u_int32_t vm;
-  u_int32_t vn = *core->registers[core->current_bank][core->thumb_instruction.dpr0.rn];
-  u_int32_t type;
+  uint32_t rd = core->thumb_instruction.dpi0.rd;
+  uint32_t vm;
+  uint32_t vn = *core->registers[core->current_bank][core->thumb_instruction.dpr0.rn];
+  uint32_t type;
   
   //For op2 both dpr0 and dpi0 are the same
   switch(core->thumb_instruction.dpr0.op2)
@@ -470,10 +470,10 @@ void ArmV5tlThumbDP0(PARMV5TL_CORE core)
 void ArmV5tlThumbDP1(PARMV5TL_CORE core)
 {
   //Get the input data.
-  u_int32_t rd = core->thumb_instruction.dp1.rd;
-  u_int32_t vm = core->thumb_instruction.dp1.im;
-  u_int32_t vn = *core->registers[core->current_bank][core->thumb_instruction.dp1.rd];
-  u_int32_t type;
+  uint32_t rd = core->thumb_instruction.dp1.rd;
+  uint32_t vm = core->thumb_instruction.dp1.im;
+  uint32_t vn = *core->registers[core->current_bank][core->thumb_instruction.dp1.rd];
+  uint32_t type;
   
   //For type 1 the op1 is the select for the type of function to perform
   switch(core->thumb_instruction.dp1.op1)
@@ -508,10 +508,10 @@ void ArmV5tlThumbDP1(PARMV5TL_CORE core)
 void ArmV5tlThumbDP2(PARMV5TL_CORE core)
 {
   //Get the input data.
-  u_int32_t rd = core->thumb_instruction.dp2.rd;
-  u_int32_t vm = *core->registers[core->current_bank][core->thumb_instruction.dp2.rm];
-  u_int32_t vn = *core->registers[core->current_bank][core->thumb_instruction.dp2.rd];
-  u_int32_t type;
+  uint32_t rd = core->thumb_instruction.dp2.rd;
+  uint32_t vm = *core->registers[core->current_bank][core->thumb_instruction.dp2.rm];
+  uint32_t vn = *core->registers[core->current_bank][core->thumb_instruction.dp2.rd];
+  uint32_t type;
   
   //For type 2 dp2 op2 tells which function to perform. Some have already been filtered out in the decoding process.
   switch(core->thumb_instruction.dp2.op2)
@@ -586,10 +586,10 @@ void ArmV5tlThumbDP2(PARMV5TL_CORE core)
 void ArmV5tlThumbDP2S(PARMV5TL_CORE core)
 {
  //Get the input data. rd is a combination of the h (high) bit and the three rd bits
-  u_int32_t rd = core->thumb_instruction.dp2s.rd | (core->thumb_instruction.dp2s.h << 3);
-  u_int32_t vm = *core->registers[core->current_bank][core->thumb_instruction.dp2s.rm];
-  u_int32_t vn = *core->registers[core->current_bank][rd];
-  u_int32_t type;
+  uint32_t rd = core->thumb_instruction.dp2s.rd | (core->thumb_instruction.dp2s.h << 3);
+  uint32_t vm = *core->registers[core->current_bank][core->thumb_instruction.dp2s.rm];
+  uint32_t vn = *core->registers[core->current_bank][rd];
+  uint32_t type;
   
   //Not sure about this. Manual does not give enogh info
   //Amend the values when r15 (pc) is used
@@ -629,11 +629,11 @@ void ArmV5tlThumbDP2S(PARMV5TL_CORE core)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Actual data processing handling
-void ArmV5tlThumbDP(PARMV5TL_CORE core, u_int32_t type, u_int32_t  rd, u_int32_t vn, u_int32_t vm)
+void ArmV5tlThumbDP(PARMV5TL_CORE core, uint32_t type, uint32_t  rd, uint32_t vn, uint32_t vm)
 {
-  u_int64_t vd;
-  u_int32_t update = 1;
-  u_int32_t docandv = ARM_FLAGS_UPDATE_CV_NO;
+  uint64_t vd;
+  uint32_t update = 1;
+  uint32_t docandv = ARM_FLAGS_UPDATE_CV_NO;
   
   //Check if NEG
   if(type & ARM_OPCODE_THUMB_NEG)
@@ -818,11 +818,11 @@ void ArmV5tlThumbDP(PARMV5TL_CORE core, u_int32_t type, u_int32_t  rd, u_int32_t
 void ArmV5tlThumbLS2I(PARMV5TL_CORE core)
 {
  //Get the input data
-  u_int32_t rd = core->thumb_instruction.ls2i.rd;
-  u_int32_t vm = core->thumb_instruction.ls2i.im * 4;
-  u_int32_t vn = (*core->program_counter + 4) & 0xFFFFFFFC;
-  u_int32_t type;
-  u_int32_t address = vn + vm;
+  uint32_t rd = core->thumb_instruction.ls2i.rd;
+  uint32_t vm = core->thumb_instruction.ls2i.im * 4;
+  uint32_t vn = (*core->program_counter + 4) & 0xFFFFFFFC;
+  uint32_t type;
+  uint32_t address = vn + vm;
 
   //Signal loading of a word
   type = ARM_MEMORY_WORD | ARM_THUMB_LOAD_FLAG;
@@ -836,11 +836,11 @@ void ArmV5tlThumbLS2I(PARMV5TL_CORE core)
 void ArmV5tlThumbLS2R(PARMV5TL_CORE core)
 {
  //Get the input data
-  u_int32_t rd = core->thumb_instruction.ls2r.rd;
-  u_int32_t vm = *core->registers[core->current_bank][core->thumb_instruction.ls2r.rm];
-  u_int32_t vn = *core->registers[core->current_bank][core->thumb_instruction.ls2r.rn];
-  u_int32_t type;
-  u_int32_t address = vn + vm;
+  uint32_t rd = core->thumb_instruction.ls2r.rd;
+  uint32_t vm = *core->registers[core->current_bank][core->thumb_instruction.ls2r.rm];
+  uint32_t vn = *core->registers[core->current_bank][core->thumb_instruction.ls2r.rn];
+  uint32_t type;
+  uint32_t address = vn + vm;
   
   //Check if sign extend instructions
   if(core->thumb_instruction.ls2r.op2 == 3)
@@ -883,11 +883,11 @@ void ArmV5tlThumbLS2R(PARMV5TL_CORE core)
 void ArmV5tlThumbLS3(PARMV5TL_CORE core)
 {
  //Get the input data
-  u_int32_t rd = core->thumb_instruction.ls3.rd;
-  u_int32_t vm = core->thumb_instruction.ls3.im * 4;
-  u_int32_t vn = *core->registers[core->current_bank][core->thumb_instruction.ls3.rn];
-  u_int32_t type;
-  u_int32_t address = vn + vm;
+  uint32_t rd = core->thumb_instruction.ls3.rd;
+  uint32_t vm = core->thumb_instruction.ls3.im * 4;
+  uint32_t vn = *core->registers[core->current_bank][core->thumb_instruction.ls3.rn];
+  uint32_t type;
+  uint32_t address = vn + vm;
 
   //Set the correct size for the given instruction
   if(core->thumb_instruction.ls3.type == 4)
@@ -922,11 +922,11 @@ void ArmV5tlThumbLS3(PARMV5TL_CORE core)
 void ArmV5tlThumbLS4(PARMV5TL_CORE core)
 {
  //Get the input data. Instruction format is the same as for type 2 immediate indexed so reusing it here
-  u_int32_t rd = core->thumb_instruction.ls2i.rd;
-  u_int32_t vm = core->thumb_instruction.ls2i.im * 4;
-  u_int32_t vn = (*core->registers[core->current_bank][13]) & 0xFFFFFFFC;
-  u_int32_t type = ARM_MEMORY_WORD;
-  u_int32_t address = vn + vm;
+  uint32_t rd = core->thumb_instruction.ls2i.rd;
+  uint32_t vm = core->thumb_instruction.ls2i.im * 4;
+  uint32_t vn = (*core->registers[core->current_bank][13]) & 0xFFFFFFFC;
+  uint32_t type = ARM_MEMORY_WORD;
+  uint32_t address = vn + vm;
 
   //Check if load or store
   if(core->thumb_instruction.ls2i.op1 == 3)
@@ -941,10 +941,10 @@ void ArmV5tlThumbLS4(PARMV5TL_CORE core)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Thumb load and store instruction handling
-void ArmV5tlThumbLS(PARMV5TL_CORE core, u_int32_t type, u_int32_t rd, u_int32_t address)
+void ArmV5tlThumbLS(PARMV5TL_CORE core, uint32_t type, uint32_t rd, uint32_t address)
 {
   void *memory;
-  u_int32_t mode = type & ARM_MEMORY_MASK;
+  uint32_t mode = type & ARM_MEMORY_MASK;
 
   //Get a pointer to the memory for the given address and type
   memory = ArmV5tlGetMemoryPointer(core, address, mode);
@@ -967,7 +967,7 @@ void ArmV5tlThumbLS(PARMV5TL_CORE core, u_int32_t type, u_int32_t rd, u_int32_t 
         if(type & ARM_THUMB_LOAD_FLAG)
         {
           //Load from memory address
-          *core->registers[core->current_bank][rd] = *(u_int8_t *)memory;
+          *core->registers[core->current_bank][rd] = *(uint8_t *)memory;
 
           //Check if sign extend needed
           if((type & ARM_THUMB_SIGN_EXTEND) && (*core->registers[core->current_bank][rd] & 0x80))
@@ -978,7 +978,7 @@ void ArmV5tlThumbLS(PARMV5TL_CORE core, u_int32_t type, u_int32_t rd, u_int32_t 
         else
         {
           //Store to memory address
-          *(u_int8_t *)memory = (u_int8_t)*core->registers[core->current_bank][rd];
+          *(uint8_t *)memory = (uint8_t)*core->registers[core->current_bank][rd];
         }
         break;
 
@@ -987,7 +987,7 @@ void ArmV5tlThumbLS(PARMV5TL_CORE core, u_int32_t type, u_int32_t rd, u_int32_t 
         if(type & ARM_THUMB_LOAD_FLAG)
         {
           //Load from memory address
-          *core->registers[core->current_bank][rd] = *(u_int16_t *)memory;
+          *core->registers[core->current_bank][rd] = *(uint16_t *)memory;
 
           //Check if sign extend needed
           if((type & ARM_THUMB_SIGN_EXTEND) && (*core->registers[core->current_bank][rd] & 0x8000))
@@ -998,7 +998,7 @@ void ArmV5tlThumbLS(PARMV5TL_CORE core, u_int32_t type, u_int32_t rd, u_int32_t 
         else
         {
           //Store to memory address
-          *(u_int16_t *)memory = (u_int16_t)*core->registers[core->current_bank][rd];
+          *(uint16_t *)memory = (uint16_t)*core->registers[core->current_bank][rd];
         }
         break;
 
@@ -1007,12 +1007,12 @@ void ArmV5tlThumbLS(PARMV5TL_CORE core, u_int32_t type, u_int32_t rd, u_int32_t 
         if(type & ARM_THUMB_LOAD_FLAG)
         {
           //Load from memory address
-          *core->registers[core->current_bank][rd] = *(u_int32_t *)memory;
+          *core->registers[core->current_bank][rd] = *(uint32_t *)memory;
         }
         else
         {
           //Store to memory address
-          *(u_int32_t *)memory = *core->registers[core->current_bank][rd];
+          *(uint32_t *)memory = *core->registers[core->current_bank][rd];
         }
         break;
     }
@@ -1050,11 +1050,11 @@ void ArmV5tlThumbLS(PARMV5TL_CORE core, u_int32_t type, u_int32_t rd, u_int32_t 
 //Load and store multiple instruction handling
 void ArmV5tlThumbLSMIA(PARMV5TL_CORE core)
 {
-  u_int32_t address = *core->registers[core->current_bank][core->thumb_instruction.lsm.rn];
-  u_int32_t traceaddress = address;
-  u_int32_t *memory;
-  u_int32_t reglist = core->thumb_instruction.lsm.rl;
-  u_int32_t mode = ARM_MEMORY_WORD;
+  uint32_t  address = *core->registers[core->current_bank][core->thumb_instruction.lsm.rn];
+  uint32_t  traceaddress = address;
+  uint32_t *memory;
+  uint32_t  reglist = core->thumb_instruction.lsm.rl;
+  uint32_t  mode = ARM_MEMORY_WORD;
   int       numregs = 0;
   int       update = 1;
   int       i;
@@ -1145,10 +1145,10 @@ void ArmV5tlThumbLSMIA(PARMV5TL_CORE core)
 //Pop instruction handling
 void ArmV5tlThumbPOP(PARMV5TL_CORE core)
 {
-  u_int32_t address = *core->registers[core->current_bank][13];
-  u_int32_t traceaddress = address;
-  u_int32_t *memory;
-  u_int32_t reglist = core->thumb_instruction.lsm.rl;
+  uint32_t  address = *core->registers[core->current_bank][13];
+  uint32_t  traceaddress = address;
+  uint32_t *memory;
+  uint32_t  reglist = core->thumb_instruction.lsm.rl;
   int       numregs = 0;
   int       i;
   
@@ -1226,10 +1226,10 @@ void ArmV5tlThumbPOP(PARMV5TL_CORE core)
 void ArmV5tlThumbPUSH(PARMV5TL_CORE core)
 {
   //For a push an extra 4 needs to be subtracted from the start address (decrement before)
-  u_int32_t address = *core->registers[core->current_bank][13] - 4;
-  u_int32_t traceaddress = address;
-  u_int32_t *memory;
-  u_int32_t reglist = core->thumb_instruction.lsm.rl;
+  uint32_t  address = *core->registers[core->current_bank][13] - 4;
+  uint32_t  traceaddress = address;
+  uint32_t *memory;
+  uint32_t  reglist = core->thumb_instruction.lsm.rl;
   int       numregs = 0;
   int       i;
   
@@ -1303,7 +1303,7 @@ void ArmV5tlThumbPUSH(PARMV5TL_CORE core)
 //Type 2 instructions branch handling
 void ArmV5tlThumbBranch2(PARMV5TL_CORE core)
 {
-  u_int32_t vm = *core->registers[core->current_bank][core->thumb_instruction.b2.rm];
+  uint32_t vm = *core->registers[core->current_bank][core->thumb_instruction.b2.rm];
   
   //When the program counter is used the value needs to be plus 4
   if(core->thumb_instruction.b2.rm == 15)
@@ -1332,8 +1332,8 @@ void ArmV5tlThumbBranch2(PARMV5TL_CORE core)
 //Type 6 instructions branch handling
 void ArmV5tlThumbBranch6(PARMV5TL_CORE core)
 {
-  u_int32_t vm;
-  u_int32_t execute = 0;
+  uint32_t vm;
+  uint32_t execute = 0;
 
   //Check the condition bits against the status bits to decide if the branch needs to be executed
   switch(core->thumb_instruction.b6.cond)
@@ -1448,7 +1448,7 @@ void ArmV5tlThumbBranch6(PARMV5TL_CORE core)
 //Type 7 instructions branch handling
 void ArmV5tlThumbBranch7(PARMV5TL_CORE core)
 {
-  u_int32_t vm;
+  uint32_t vm;
 
   //Check on unconditional branch
   if(core->thumb_instruction.b7.op1 == 0)

--- a/Test code/Scope_emulator/armv5tl_thumb.h
+++ b/Test code/Scope_emulator/armv5tl_thumb.h
@@ -28,20 +28,20 @@ void ArmV5tlHandleThumb(PARMV5TL_CORE core);
 
 void ArmV5tlThumbShiftImmediate(PARMV5TL_CORE core);
 void ArmV5tlThumbShiftRegister(PARMV5TL_CORE core);
-void ArmV5tlThumbShift(PARMV5TL_CORE core, u_int32_t type, u_int32_t sa, u_int32_t vm);
+void ArmV5tlThumbShift(PARMV5TL_CORE core, uint32_t type, uint32_t sa, uint32_t vm);
 
 void ArmV5tlThumbDP0(PARMV5TL_CORE core);
 void ArmV5tlThumbDP1(PARMV5TL_CORE core);
 void ArmV5tlThumbDP2(PARMV5TL_CORE core);
 void ArmV5tlThumbDP2S(PARMV5TL_CORE core);
-void ArmV5tlThumbDP(PARMV5TL_CORE core, u_int32_t type, u_int32_t rd, u_int32_t vn, u_int32_t vm);
+void ArmV5tlThumbDP(PARMV5TL_CORE core, uint32_t type, uint32_t rd, uint32_t vn, uint32_t vm);
 
 void ArmV5tlThumbLS2I(PARMV5TL_CORE core);
 void ArmV5tlThumbLS2R(PARMV5TL_CORE core);
 void ArmV5tlThumbLS3(PARMV5TL_CORE core);
 void ArmV5tlThumbLS4(PARMV5TL_CORE core);
 
-void ArmV5tlThumbLS(PARMV5TL_CORE core, u_int32_t type, u_int32_t rd, u_int32_t address);
+void ArmV5tlThumbLS(PARMV5TL_CORE core, uint32_t type, uint32_t rd, uint32_t address);
 
 void ArmV5tlThumbLSMIA(PARMV5TL_CORE core);
 

--- a/Test code/Scope_emulator/armv5tl_thumb_structs.h
+++ b/Test code/Scope_emulator/armv5tl_thumb_structs.h
@@ -3,6 +3,8 @@
 #ifndef ARMV5TL_THUMB_STRCUTS_H
 #define ARMV5TL_THUMB_STRCUTS_H
 
+#include <stdint.h>
+
 //----------------------------------------------------------------------------------------------------------------------------------
 
 typedef union  tagARMV5TL_THUMB_INSTRUCTION  ARMV5TL_THUMB_INSTRUCTION;
@@ -29,143 +31,143 @@ typedef struct tagARMV5TL_INSTR_THUMB_B7     ARMV5TL_INSTR_THUMB_B7;
 
 struct tagARMV5TL_INSTR_THUMB_BASE
 {
-  u_int32_t data:6;       //Instruction data
-  u_int32_t op2:5;        //Extended opcode
-  u_int32_t op1:2;        //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
+  uint32_t data:6;        //Instruction data
+  uint32_t op2:5;         //Extended opcode
+  uint32_t op1:2;         //Actual opcode for some type of instructions
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_SHIFT0
 {
-  u_int32_t rd:3;         //Destination register
-  u_int32_t rm:3;         //Source register
-  u_int32_t sa:5;         //5 bits shift amount
-  u_int32_t op1:2;        //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
+  uint32_t rd:3;          //Destination register
+  uint32_t rm:3;          //Source register
+  uint32_t sa:5;          //5 bits shift amount
+  uint32_t op1:2;         //Actual opcode for some type of instructions
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_SHIFT2
 {
-  u_int32_t rd:3;         //Destination register
-  u_int32_t rs:3;         //Shift amount register
-  u_int32_t op2:5;        //Extra opcode
-  u_int32_t op1:2;        //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
+  uint32_t rd:3;          //Destination register
+  uint32_t rs:3;          //Shift amount register
+  uint32_t op2:5;         //Extra opcode
+  uint32_t op1:2;         //Actual opcode for some type of instructions
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_DPI0
 {
-  u_int32_t rd:3;         //Destination register
-  u_int32_t rn:3;         //Source register
-  u_int32_t im:3;         //3 bits immediate data
-  u_int32_t op2:2;        //Extra opcode for some type of instructions
-  u_int32_t op1:2;        //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
+  uint32_t rd:3;          //Destination register
+  uint32_t rn:3;          //Source register
+  uint32_t im:3;          //3 bits immediate data
+  uint32_t op2:2;         //Extra opcode for some type of instructions
+  uint32_t op1:2;         //Actual opcode for some type of instructions
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_DPR0
 {
-  u_int32_t rd:3;         //Destination register
-  u_int32_t rn:3;         //Source register
-  u_int32_t rm:3;         //Second source register
-  u_int32_t op2:2;        //Extra opcode for some type of instructions
-  u_int32_t op1:2;        //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
+  uint32_t rd:3;          //Destination register
+  uint32_t rn:3;          //Source register
+  uint32_t rm:3;          //Second source register
+  uint32_t op2:2;         //Extra opcode for some type of instructions
+  uint32_t op1:2;         //Actual opcode for some type of instructions
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_DP1
 {
-  u_int32_t im:8;         //Immediate data
-  u_int32_t rd:3;         //Destination register
-  u_int32_t op1:2;        //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
+  uint32_t im:8;          //Immediate data
+  uint32_t rd:3;          //Destination register
+  uint32_t op1:2;         //Actual opcode for some type of instructions
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_DP2
 {
-  u_int32_t rd:3;         //Destination register
-  u_int32_t rm:3;         //Source register
-  u_int32_t op2:5;        //Extra opcode for some type of instructions
-  u_int32_t op1:2;        //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
+  uint32_t rd:3;          //Destination register
+  uint32_t rm:3;          //Source register
+  uint32_t op2:5;         //Extra opcode for some type of instructions
+  uint32_t op1:2;         //Actual opcode for some type of instructions
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_DP2S
 {
-  u_int32_t rd:3;         //Destination register
-  u_int32_t rm:4;         //Source register
-  u_int32_t h:1;          //High bit of rd
-  u_int32_t op2:3;        //Extra opcode for some type of instructions
-  u_int32_t op1:2;        //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
+  uint32_t rd:3;          //Destination register
+  uint32_t rm:4;          //Source register
+  uint32_t h:1;           //High bit of rd
+  uint32_t op2:3;         //Extra opcode for some type of instructions
+  uint32_t op1:2;         //Actual opcode for some type of instructions
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_LS2I
 {
-  u_int32_t im:8;         //Immediate data
-  u_int32_t rd:3;         //Destination register
-  u_int32_t op1:2;        //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
+  uint32_t im:8;          //Immediate data
+  uint32_t rd:3;          //Destination register
+  uint32_t op1:2;         //Actual opcode for some type of instructions
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_LS2R
 {
-  u_int32_t rd:3;         //Destination register
-  u_int32_t rn:3;         //Source register
-  u_int32_t rm:3;         //Second source register
-  u_int32_t op2:2;        //Extra opcode for some type of instructions
-  u_int32_t op1:2;        //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
+  uint32_t rd:3;          //Destination register
+  uint32_t rn:3;          //Source register
+  uint32_t rm:3;          //Second source register
+  uint32_t op2:2;         //Extra opcode for some type of instructions
+  uint32_t op1:2;         //Actual opcode for some type of instructions
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_LS3
 {
-  u_int32_t rd:3;         //Destination register
-  u_int32_t rn:3;         //Source register
-  u_int32_t im:5;         //5 bit immediate index
-  u_int32_t l:1;          //Load / store bit
-  u_int32_t b:1;          //byte / word bit
-  u_int32_t type:3;       //Type of instructions
+  uint32_t rd:3;          //Destination register
+  uint32_t rn:3;          //Source register
+  uint32_t im:5;          //5 bit immediate index
+  uint32_t l:1;           //Load / store bit
+  uint32_t b:1;           //byte / word bit
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_LSM
 {
-  u_int32_t rl:8;         //Register list
-  u_int32_t rn:3;         //Base register
-  u_int32_t l:1;          //Load / store bit
-  u_int32_t nu:1;         //Not used
-  u_int32_t type:3;       //Type of instructions
+  uint32_t rl:8;          //Register list
+  uint32_t rn:3;          //Base register
+  uint32_t l:1;           //Load / store bit
+  uint32_t nu:1;          //Not used
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_B2
 {
-  u_int32_t sbz:3;        //Should be zero
-  u_int32_t rm:4;         //Register holding target address
-  u_int32_t op2:4;        //Extra opcode for some type of instructions
-  u_int32_t op1:2;        //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
+  uint32_t sbz:3;         //Should be zero
+  uint32_t rm:4;          //Register holding target address
+  uint32_t op2:4;         //Extra opcode for some type of instructions
+  uint32_t op1:2;         //Actual opcode for some type of instructions
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_B6
 {
-  u_int32_t im:8;         //signed immediate
-  u_int32_t cond:4;       //Condition for execute
-  u_int32_t op1:1;        //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
+  uint32_t im:8;          //signed immediate
+  uint32_t cond:4;        //Condition for execute
+  uint32_t op1:1;         //Actual opcode for some type of instructions
+  uint32_t type:3;        //Type of instructions
 };
 
 struct tagARMV5TL_INSTR_THUMB_B7
 {
-  u_int32_t im:11;        //signed immediate
-  u_int32_t op1:2;        //Actual opcode for some type of instructions
-  u_int32_t type:3;       //Type of instructions
+  uint32_t im:11;         //signed immediate
+  uint32_t op1:2;         //Actual opcode for some type of instructions
+  uint32_t type:3;        //Type of instructions
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
 
 union tagARMV5TL_THUMB_INSTRUCTION
 {
-  u_int16_t                  instr;       //Instruction register
+  uint16_t                   instr;       //Instruction register
   ARMV5TL_INSTR_THUMB_BASE   base;        //Base type for decoding
   ARMV5TL_INSTR_THUMB_SHIFT0 shift0;      //Instruction data for type 0 shift instructions
   ARMV5TL_INSTR_THUMB_SHIFT2 shift2;      //Instruction data for type 2 shift instructions

--- a/Test code/Scope_emulator/f1c100s.c
+++ b/Test code/Scope_emulator/f1c100s.c
@@ -30,9 +30,9 @@ void F1C100sProcess(PARMV5TL_CORE core)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Memory handlers
-void *F1C100sSram1(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void *F1C100sSram1(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
-  u_int32_t idx = address >> 2;
+  uint32_t idx = address >> 2;
   
   switch(mode)
   {
@@ -52,9 +52,9 @@ void *F1C100sSram1(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
   return(NULL);
 }
 
-void *F1C100sSram2(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void *F1C100sSram2(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
-  u_int32_t idx = address >> 2;
+  uint32_t idx = address >> 2;
   
   switch(mode)
   {
@@ -74,9 +74,9 @@ void *F1C100sSram2(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
   return(NULL);
 }
 
-void *F1C100sDDR(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void *F1C100sDDR(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
-  u_int32_t idx = address >> 2;
+  uint32_t idx = address >> 2;
   
   switch(mode)
   {

--- a/Test code/Scope_emulator/f1c100s.h
+++ b/Test code/Scope_emulator/f1c100s.h
@@ -87,74 +87,74 @@ void F1C100sResetSPI0(PARMV5TL_CORE core);
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Memory map functions
-void *F1C100sSram1(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void *F1C100sSram2(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void *F1C100sDDR(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
+void *F1C100sSram1(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void *F1C100sSram2(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void *F1C100sDDR(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
 
 //Clock control registers
-void *F1C100sCCU(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sCCURead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sCCUWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
+void *F1C100sCCU(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sCCURead(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sCCUWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
 
 //DRAM control registers
-void *F1C100sDRAMC(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sDRAMCRead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sDRAMCWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
+void *F1C100sDRAMC(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sDRAMCRead(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sDRAMCWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
 
 //Interrupt control registers
-void *F1C100sINTC(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sINTCRead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sINTCWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
+void *F1C100sINTC(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sINTCRead(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sINTCWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
 
 //Timer control registers
-void *F1C100sTimer(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sTimerRead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sTimerWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
+void *F1C100sTimer(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sTimerRead(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sTimerWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
 
 //SPI control registers
-void *F1C100sSPI0(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sSPI0Read(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sSPI0Write(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
+void *F1C100sSPI0(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sSPI0Read(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sSPI0Write(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
 
-void *F1C100sSPI(F1C100S_SPI *registers, u_int32_t address, u_int32_t mode);
-void F1C100sSPIRead(F1C100S_SPI *registers, u_int32_t address, u_int32_t mode);
-void F1C100sSPIWrite(PARMV5TL_CORE core, F1C100S_SPI *registers, u_int32_t address, u_int32_t mode);
+void *F1C100sSPI(F1C100S_SPI *registers, uint32_t address, uint32_t mode);
+void F1C100sSPIRead(F1C100S_SPI *registers, uint32_t address, uint32_t mode);
+void F1C100sSPIWrite(PARMV5TL_CORE core, F1C100S_SPI *registers, uint32_t address, uint32_t mode);
 
 //UART control registers
-void *F1C100sUART0(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sUART0Read(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sUART0Write(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
+void *F1C100sUART0(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sUART0Read(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sUART0Write(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
 
-void *F1C100sUART(F1C100S_UART *registers, u_int32_t address, u_int32_t mode);
-void F1C100sUARTRead(F1C100S_UART *registers, u_int32_t address, u_int32_t mode);
-void F1C100sUARTWrite(F1C100S_UART *registers, u_int32_t address, u_int32_t mode);
+void *F1C100sUART(F1C100S_UART *registers, uint32_t address, uint32_t mode);
+void F1C100sUARTRead(F1C100S_UART *registers, uint32_t address, uint32_t mode);
+void F1C100sUARTWrite(F1C100S_UART *registers, uint32_t address, uint32_t mode);
 
 //PIO control registers
-void *F1C100sPIO(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void *F1C100sPIOPort(F1C100S_PIO_PORT *registers, u_int32_t address, u_int32_t mode);
-void *F1C100sPIOInt(F1C100S_PIO_INT *registers, u_int32_t address, u_int32_t mode);
-void F1C100sPIORead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sPIOWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sPIOPortRead(F1C100S_PIO_PORT *registers, u_int32_t address, u_int32_t mode);
-void F1C100sPIOIntRead(F1C100S_PIO_INT *registers, u_int32_t address, u_int32_t mode);
-void F1C100sPIOPortWrite(F1C100S_PIO_PORT *registers, u_int32_t address, u_int32_t mode);
-void F1C100sPIOIntWrite(F1C100S_PIO_INT *registers, u_int32_t address, u_int32_t mode);
+void *F1C100sPIO(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void *F1C100sPIOPort(F1C100S_PIO_PORT *registers, uint32_t address, uint32_t mode);
+void *F1C100sPIOInt(F1C100S_PIO_INT *registers, uint32_t address, uint32_t mode);
+void F1C100sPIORead(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sPIOWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sPIOPortRead(F1C100S_PIO_PORT *registers, uint32_t address, uint32_t mode);
+void F1C100sPIOIntRead(F1C100S_PIO_INT *registers, uint32_t address, uint32_t mode);
+void F1C100sPIOPortWrite(F1C100S_PIO_PORT *registers, uint32_t address, uint32_t mode);
+void F1C100sPIOIntWrite(F1C100S_PIO_INT *registers, uint32_t address, uint32_t mode);
 
 //TCON registers
-void *F1C100sTCON(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sTCONRead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sTCONWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
+void *F1C100sTCON(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sTCONRead(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sTCONWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
 
 //DEBE registers
-void *F1C100sDEBE(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sDEBERead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
-void F1C100sDEBEWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode);
+void *F1C100sDEBE(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sDEBERead(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
+void F1C100sDEBEWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode);
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Port data handling functions
-void PortAHandler(F1C100S_PIO_PORT *registers,  u_int32_t mode);
+void PortAHandler(F1C100S_PIO_PORT *registers,  uint32_t mode);
 
-void PortEHandler(F1C100S_PIO_PORT *registers,  u_int32_t mode);
+void PortEHandler(F1C100S_PIO_PORT *registers,  uint32_t mode);
 
 //----------------------------------------------------------------------------------------------------------------------------------
 

--- a/Test code/Scope_emulator/f1c100s_ccu.c
+++ b/Test code/Scope_emulator/f1c100s_ccu.c
@@ -9,7 +9,7 @@
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Clock control registers
-void *F1C100sCCU(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void *F1C100sCCU(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   F1C100S_MEMORY *ptr = NULL;
   
@@ -218,7 +218,7 @@ void *F1C100sCCU(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Clock control register read
-void F1C100sCCURead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sCCURead(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x000003FC)
@@ -367,7 +367,7 @@ void F1C100sCCURead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Clock control register write
-void F1C100sCCUWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sCCUWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x000003FC)

--- a/Test code/Scope_emulator/f1c100s_debe.c
+++ b/Test code/Scope_emulator/f1c100s_debe.c
@@ -13,7 +13,7 @@
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //LCD timing control registers
-void *F1C100sDEBE(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void *F1C100sDEBE(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   F1C100S_MEMORY *ptr = NULL;
   
@@ -282,7 +282,7 @@ void *F1C100sDEBE(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //LCD timing control registers
-void F1C100sDEBERead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sDEBERead(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x00000FFC)
@@ -468,7 +468,7 @@ void F1C100sDEBERead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //LCD timing control registers
-void F1C100sDEBEWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sDEBEWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x00000FFC)

--- a/Test code/Scope_emulator/f1c100s_dramc.c
+++ b/Test code/Scope_emulator/f1c100s_dramc.c
@@ -8,7 +8,7 @@
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //DRAM control registers
-void *F1C100sDRAMC(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void *F1C100sDRAMC(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   F1C100S_MEMORY *ptr = NULL;
   
@@ -169,7 +169,7 @@ void *F1C100sDRAMC(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //DRAM control registers read
-void F1C100sDRAMCRead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sDRAMCRead(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x00000FFC)
@@ -278,7 +278,7 @@ void F1C100sDRAMCRead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //DRAM control registers write
-void F1C100sDRAMCWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sDRAMCWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x00000FFC)

--- a/Test code/Scope_emulator/f1c100s_intc.c
+++ b/Test code/Scope_emulator/f1c100s_intc.c
@@ -42,7 +42,7 @@ void F1C100sProcessINTC(PARMV5TL_CORE core)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Interrupt control registers
-void *F1C100sINTC(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void *F1C100sINTC(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   F1C100S_MEMORY *ptr = NULL;
   
@@ -143,7 +143,7 @@ void *F1C100sINTC(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Timer control registers read function
-void F1C100sINTCRead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sINTCRead(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   F1C100S_MEMORY *ptr = NULL;
   
@@ -209,7 +209,7 @@ void F1C100sINTCRead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Timer control registers write function
-void F1C100sINTCWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sINTCWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   F1C100S_MEMORY *ptr = NULL;
   

--- a/Test code/Scope_emulator/f1c100s_pio.c
+++ b/Test code/Scope_emulator/f1c100s_pio.c
@@ -36,10 +36,10 @@
 #define I2C_SCL_BIT            0x08
 
 //----------------------------------------------------------------------------------------------------------------------------------
-void PortAHandler(F1C100S_PIO_PORT *registers,  u_int32_t mode)
+void PortAHandler(F1C100S_PIO_PORT *registers,  uint32_t mode)
 {
   TOUCH_PANEL_DATA *pd = (TOUCH_PANEL_DATA *)registers->portdata;
-  u_int8_t address;
+  uint8_t address;
   
    //Check if there is device data
   if(pd)
@@ -284,11 +284,11 @@ void PortAHandler(F1C100S_PIO_PORT *registers,  u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Static data
-const u_int8_t tp_coord_reg[2] = { 0x81, 0x50 };
+const uint8_t tp_coord_reg[2] = { 0x81, 0x50 };
 
-const u_int8_t param_status_byte = 0x01;
+const uint8_t param_status_byte = 0x01;
 
-const u_int8_t scope_ch1_data[1600] = 
+const uint8_t scope_ch1_data[1600] =
 {
   0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0,
   0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0,
@@ -392,7 +392,7 @@ const u_int8_t scope_ch1_data[1600] =
   0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90,
 };
 
-const u_int8_t scope_ch2_data[1600] = 
+const uint8_t scope_ch2_data[1600] =
 {
   0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28,
   0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28,
@@ -499,7 +499,7 @@ const u_int8_t scope_ch2_data[1600] =
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //FPGA handling
-void PortEHandler(F1C100S_PIO_PORT *registers,  u_int32_t mode)
+void PortEHandler(F1C100S_PIO_PORT *registers,  uint32_t mode)
 {
   FPGA_DATA *pd = (FPGA_DATA *)registers->portdata;
   int i;
@@ -728,8 +728,8 @@ void PortEHandler(F1C100S_PIO_PORT *registers,  u_int32_t mode)
 
                   if(pd->param_trace)
                   {
-                    u_int32_t value;
-                    u_int32_t len = (pd->param_data[1] ^ pd->param_crypt) & 0x03;
+                    uint32_t value;
+                    uint32_t len = (pd->param_data[1] ^ pd->param_crypt) & 0x03;
                     
                     
                     //decode the data
@@ -868,7 +868,7 @@ void PortEHandler(F1C100S_PIO_PORT *registers,  u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //PIO control registers
-void *F1C100sPIO(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void *F1C100sPIO(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Check if port control register selected
   if(address < 0xD8)
@@ -932,7 +932,7 @@ void *F1C100sPIO(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //PIO control registers read
-void F1C100sPIORead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sPIORead(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   address &= 0x03FF;
   
@@ -964,7 +964,7 @@ void F1C100sPIORead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //PIO control registers read
-void F1C100sPIOWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sPIOWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   address &= 0x03FF;
 
@@ -996,7 +996,7 @@ void F1C100sPIOWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //PIO port control registers
-void *F1C100sPIOPort(F1C100S_PIO_PORT *registers, u_int32_t address, u_int32_t mode)
+void *F1C100sPIOPort(F1C100S_PIO_PORT *registers, uint32_t address, uint32_t mode)
 {
   F1C100S_MEMORY *ptr = NULL;
   
@@ -1065,7 +1065,7 @@ void *F1C100sPIOPort(F1C100S_PIO_PORT *registers, u_int32_t address, u_int32_t m
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //PIO port control registers read
-void F1C100sPIOPortRead(F1C100S_PIO_PORT *registers, u_int32_t address, u_int32_t mode)
+void F1C100sPIOPortRead(F1C100S_PIO_PORT *registers, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x0000003C)
@@ -1104,7 +1104,7 @@ void F1C100sPIOPortRead(F1C100S_PIO_PORT *registers, u_int32_t address, u_int32_
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //PIO port control registers read
-void F1C100sPIOPortWrite(F1C100S_PIO_PORT *registers, u_int32_t address, u_int32_t mode)
+void F1C100sPIOPortWrite(F1C100S_PIO_PORT *registers, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x0000003C)
@@ -1143,7 +1143,7 @@ void F1C100sPIOPortWrite(F1C100S_PIO_PORT *registers, u_int32_t address, u_int32
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //PIO interrupt control registers
-void *F1C100sPIOInt(F1C100S_PIO_INT *registers, u_int32_t address, u_int32_t mode)
+void *F1C100sPIOInt(F1C100S_PIO_INT *registers, uint32_t address, uint32_t mode)
 {
   F1C100S_MEMORY *ptr = NULL;
   
@@ -1204,7 +1204,7 @@ void *F1C100sPIOInt(F1C100S_PIO_INT *registers, u_int32_t address, u_int32_t mod
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //PIO interrupt control registers read
-void F1C100sPIOIntRead(F1C100S_PIO_INT *registers, u_int32_t address, u_int32_t mode)
+void F1C100sPIOIntRead(F1C100S_PIO_INT *registers, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x0000003C)
@@ -1234,7 +1234,7 @@ void F1C100sPIOIntRead(F1C100S_PIO_INT *registers, u_int32_t address, u_int32_t 
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //PIO interrupt control registers write
-void F1C100sPIOIntWrite(F1C100S_PIO_INT *registers, u_int32_t address, u_int32_t mode)
+void F1C100sPIOIntWrite(F1C100S_PIO_INT *registers, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x0000003C)

--- a/Test code/Scope_emulator/f1c100s_spi.c
+++ b/Test code/Scope_emulator/f1c100s_spi.c
@@ -44,7 +44,7 @@ void F1C100sResetSPI0(PARMV5TL_CORE core)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //SPI0 control registers
-void *F1C100sSPI0(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void *F1C100sSPI0(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Call the SPI handler with the registers for SPI0
   return(F1C100sSPI(&core->f1c100s_spi[0], address, mode));
@@ -52,7 +52,7 @@ void *F1C100sSPI0(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //SPI0 control registers read
-void F1C100sSPI0Read(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sSPI0Read(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Call the SPI read handler with the registers for SPI0
   F1C100sSPIRead(&core->f1c100s_spi[0], address, mode);
@@ -60,7 +60,7 @@ void F1C100sSPI0Read(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //SPI0 control registers write
-void F1C100sSPI0Write(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sSPI0Write(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Call the SPI write handler with the registers for SPI0
   F1C100sSPIWrite(core, &core->f1c100s_spi[0], address, mode);
@@ -68,7 +68,7 @@ void F1C100sSPI0Write(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //SPI control registers
-void *F1C100sSPI(F1C100S_SPI *registers, u_int32_t address, u_int32_t mode)
+void *F1C100sSPI(F1C100S_SPI *registers, uint32_t address, uint32_t mode)
 {
   F1C100S_MEMORY *ptr = NULL;
   
@@ -153,7 +153,7 @@ void *F1C100sSPI(F1C100S_SPI *registers, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //SPI control registers read
-void F1C100sSPIRead(F1C100S_SPI *registers, u_int32_t address, u_int32_t mode)
+void F1C100sSPIRead(F1C100S_SPI *registers, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x00000FFC)
@@ -213,7 +213,7 @@ void F1C100sSPIRead(F1C100S_SPI *registers, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //SPI control registers write
-void F1C100sSPIWrite(PARMV5TL_CORE core, F1C100S_SPI *registers, u_int32_t address, u_int32_t mode)
+void F1C100sSPIWrite(PARMV5TL_CORE core, F1C100S_SPI *registers, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x00000FFC)

--- a/Test code/Scope_emulator/f1c100s_structs.h
+++ b/Test code/Scope_emulator/f1c100s_structs.h
@@ -3,6 +3,9 @@
 #ifndef F1C100S_STRUCTS_H
 #define F1C100S_STRUCTS_H
 
+#include <stdint.h>   // for fixed width integer types
+#include <stdio.h>    // for FILE
+
 //----------------------------------------------------------------------------------------------------------------------------------
 
 typedef struct tagF1C100S_PERIPH_STATUS    F1C100S_PERIPH_STATUS;
@@ -36,93 +39,93 @@ typedef union tagF1C100S_MEMORY            F1C100S_MEMORY;
 
 //----------------------------------------------------------------------------------------------------------------------------------
 
-typedef void (*PORTFUNC)(F1C100S_PIO_PORT *registers, u_int32_t mode);
+typedef void (*PORTFUNC)(F1C100S_PIO_PORT *registers, uint32_t mode);
 
 //----------------------------------------------------------------------------------------------------------------------------------
 
 union tagF1C100S_MEMORY
 {
-  u_int32_t m_32bit;
+  uint32_t  m_32bit;
   int32_t   s_32bit;
-  u_int16_t m_16bit[2];
-  u_int8_t  m_8bit[4];
+  uint16_t  m_16bit[2];
+  uint8_t   m_8bit[4];
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Data for flash memory handling
 struct tagFLASH_MEMORY
 {
-  u_int32_t commandstate;
-  u_int32_t mode;
-  u_int32_t readaddress;
+  uint32_t  commandstate;
+  uint32_t  mode;
+  uint32_t  readaddress;
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Data for display handling
 struct tagDISPLAY_MEMORY
 {
-  u_int32_t startaddress;            //Start of the video buffer in the core memory
-  u_int32_t linewidth;               //Number of bytes per line
-  u_int32_t xsize;                   //Number of x pixels
-  u_int32_t ysize;                   //Number of y pixels
-  u_int64_t prevcycles;              //CPU cycles count last vertical sync was triggered on
-  u_int64_t numcycles;               //Number of CPU cycles needed for a vertical trigger to occur
-  u_int32_t linetime;                //Number of cpu cycles for a line
-  u_int32_t verticaltime;            //Number of lines for vertical front and back porch
+  uint32_t  startaddress;            //Start of the video buffer in the core memory
+  uint32_t  linewidth;               //Number of bytes per line
+  uint32_t  xsize;                   //Number of x pixels
+  uint32_t  ysize;                   //Number of y pixels
+  uint64_t  prevcycles;              //CPU cycles count last vertical sync was triggered on
+  uint64_t  numcycles;               //Number of CPU cycles needed for a vertical trigger to occur
+  uint32_t  linetime;                //Number of cpu cycles for a line
+  uint32_t  verticaltime;            //Number of lines for vertical front and back porch
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Data for touch panel handling
 struct tagTOUCH_PANEL_DATA
 {
-  u_int8_t  i2c_currentbyte;
-  u_int8_t  i2c_currentbit;
-  u_int8_t  i2c_state;
+  uint8_t   i2c_currentbyte;
+  uint8_t   i2c_currentbit;
+  uint8_t   i2c_state;
   
-  u_int8_t  panel_state;              //Process state for the panel state machine
-  u_int8_t  panel_mode;               //Data direction mode for the current data stream
-  u_int16_t panel_address;            //Internal address for panel read and write actions
-  u_int8_t  panel_data[0x200];        //Panel has a lot of registers. For easy implementation set to 0x200 (address range 0x8000 - 0x8200)
+  uint8_t   panel_state;              //Process state for the panel state machine
+  uint8_t   panel_mode;               //Data direction mode for the current data stream
+  uint16_t  panel_address;            //Internal address for panel read and write actions
+  uint8_t   panel_data[0x200];        //Panel has a lot of registers. For easy implementation set to 0x200 (address range 0x8000 - 0x8200)
   
-  u_int8_t  prev_port_data;
+  uint8_t   prev_port_data;
   
-  u_int8_t  mouse_down;               //Signal from mouse touch panel that there is touch
-  u_int8_t  mouse_prev;               //Previous value to detect the change from touch to no touch
+  uint8_t   mouse_down;               //Signal from mouse touch panel that there is touch
+  uint8_t   mouse_prev;               //Previous value to detect the change from touch to no touch
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Data for FPGA handling
 struct tagFPGA_DATA
 {
-  u_int8_t        current_command;
-  u_int16_t       read_count;
-  const u_int8_t *read_ptr;
-  u_int16_t       write_count;
-  u_int8_t       *write_ptr;
-  u_int8_t        prev_ctrl_bits;
+  uint8_t         current_command;
+  uint16_t        read_count;
+  const uint8_t  *read_ptr;
+  uint16_t        write_count;
+  uint8_t        *write_ptr;
+  uint8_t         prev_ctrl_bits;
   
   //Data for parameter storage system
-  u_int8_t   param_state;
-  u_int8_t   param_crypt;
-  u_int8_t   param_mode;
-  u_int8_t   param_id;
-  u_int8_t   param_data[7];
+  uint8_t    param_state;
+  uint8_t    param_crypt;
+  uint8_t    param_mode;
+  uint8_t    param_id;
+  uint8_t    param_data[7];
   FILE      *param_file;
   FILE      *param_trace;
   
-  u_int8_t   cmd0x14count[2];
+  uint8_t    cmd0x14count[2];
 
-  u_int8_t   cmd0x21data[2];
+  uint8_t    cmd0x21data[2];
   
   
-  u_int8_t   tracedata[1500];
-  u_int32_t  tracecount;
-  u_int32_t  datamode;
+  uint8_t    tracedata[1500];
+  uint32_t   tracecount;
+  uint32_t   datamode;
   
-  u_int32_t  print_command;
+  uint32_t   print_command;
   char       file_name[128];
-  u_int32_t  file_line_count;
-  u_int32_t  file_index;
+  uint32_t   file_line_count;
+  uint32_t   file_index;
   FILE      *trace_file;
 };
 
@@ -130,8 +133,8 @@ struct tagFPGA_DATA
 //Peripheral reset status info
 struct tagF1C100S_PERIPH_STATUS
 {
-  u_int32_t spi0_reset;
-  u_int32_t spi1_reset;
+  uint32_t spi0_reset;
+  uint32_t spi1_reset;
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
@@ -245,7 +248,7 @@ struct tagF1C100S_INTC
   F1C100S_MEMORY prio3;
   
   //Internal interrupt status bits
-  u_int32_t interruptstatus[2];
+  uint32_t interruptstatus[2];
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
@@ -278,11 +281,11 @@ struct tagF1C100S_TIMER
   int32_t prescalerreload[5];
   
   //Timer control previous values for start detect
-  u_int32_t ctrl_previous[5];
+  uint32_t ctrl_previous[5];
   
   //Timer interrupt status bits
-  u_int32_t interruptstatus;
-  u_int32_t interruptrequest;
+  uint32_t interruptstatus;
+  uint32_t interruptrequest;
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
@@ -304,8 +307,8 @@ struct tagF1C100S_SPI
   F1C100S_MEMORY rxd;
   
   //Not directly addressable are the two fifo's each spi interface has
-  u_int8_t txfifo[64];
-  u_int8_t rxfifo[64];
+  uint8_t txfifo[64];
+  uint8_t rxfifo[64];
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------
@@ -332,17 +335,17 @@ struct tagF1C100S_UART
   F1C100S_MEMORY dbg_dlh;
 
   //Internal registers
-  u_int32_t rbr;
-  u_int32_t thr;
-  u_int32_t dll;
-  u_int32_t dlh;
-  u_int32_t ier;
-  u_int32_t iir;
-  u_int32_t fcr;
+  uint32_t rbr;
+  uint32_t thr;
+  uint32_t dll;
+  uint32_t dlh;
+  uint32_t ier;
+  uint32_t iir;
+  uint32_t fcr;
   
   //Not directly addressable are the two fifo's each uart interface has
-  u_int8_t txfifo[64];
-  u_int8_t rxfifo[64];
+  uint8_t txfifo[64];
+  uint8_t rxfifo[64];
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------

--- a/Test code/Scope_emulator/f1c100s_tcon.c
+++ b/Test code/Scope_emulator/f1c100s_tcon.c
@@ -29,7 +29,7 @@ void F1C100sProcessTCON(PARMV5TL_CORE core)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //LCD timing control registers
-void *F1C100sTCON(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void *F1C100sTCON(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   F1C100S_MEMORY *ptr = NULL;
   
@@ -210,7 +210,7 @@ void *F1C100sTCON(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //LCD timing control registers read function
-void F1C100sTCONRead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sTCONRead(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x000003FC)
@@ -330,7 +330,7 @@ void F1C100sTCONRead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //LCD timing control registers write function
-void F1C100sTCONWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sTCONWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x000003FC)

--- a/Test code/Scope_emulator/f1c100s_timer.c
+++ b/Test code/Scope_emulator/f1c100s_timer.c
@@ -48,7 +48,7 @@ void F1C100sProcessTimer(PARMV5TL_CORE core)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Timer control registers
-void *F1C100sTimer(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void *F1C100sTimer(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   F1C100S_MEMORY *ptr = NULL;
   
@@ -161,7 +161,7 @@ void *F1C100sTimer(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Timer control registers read function
-void F1C100sTimerRead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sTimerRead(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x000000FC)
@@ -232,7 +232,7 @@ void F1C100sTimerRead(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //Timer control registers write function
-void F1C100sTimerWrite(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sTimerWrite(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x000000FC)

--- a/Test code/Scope_emulator/f1c100s_uart.c
+++ b/Test code/Scope_emulator/f1c100s_uart.c
@@ -12,7 +12,7 @@
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //UART0 control registers
-void *F1C100sUART0(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void *F1C100sUART0(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Call the SPI handler with the registers for SPI0
   return(F1C100sUART(&core->f1c100s_uart[0], address, mode));
@@ -20,7 +20,7 @@ void *F1C100sUART0(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //UART0 control registers read
-void F1C100sUART0Read(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sUART0Read(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Call the SPI read handler with the registers for SPI0
   F1C100sUARTRead(&core->f1c100s_uart[0], address, mode);
@@ -28,7 +28,7 @@ void F1C100sUART0Read(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //UART0 control registers write
-void F1C100sUART0Write(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
+void F1C100sUART0Write(PARMV5TL_CORE core, uint32_t address, uint32_t mode)
 {
   //Call the SPI write handler with the registers for SPI0
   F1C100sUARTWrite(&core->f1c100s_uart[0], address, mode);
@@ -36,7 +36,7 @@ void F1C100sUART0Write(PARMV5TL_CORE core, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //UART control registers
-void *F1C100sUART(F1C100S_UART *registers, u_int32_t address, u_int32_t mode)
+void *F1C100sUART(F1C100S_UART *registers, uint32_t address, uint32_t mode)
 {
   F1C100S_MEMORY *ptr = NULL;
   
@@ -129,7 +129,7 @@ void *F1C100sUART(F1C100S_UART *registers, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //UART control registers read
-void F1C100sUARTRead(F1C100S_UART *registers, u_int32_t address, u_int32_t mode)
+void F1C100sUARTRead(F1C100S_UART *registers, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x00000FFC)
@@ -184,7 +184,7 @@ void F1C100sUARTRead(F1C100S_UART *registers, u_int32_t address, u_int32_t mode)
 
 //----------------------------------------------------------------------------------------------------------------------------------
 //UART control registers write
-void F1C100sUARTWrite(F1C100S_UART *registers, u_int32_t address, u_int32_t mode)
+void F1C100sUARTWrite(F1C100S_UART *registers, uint32_t address, uint32_t mode)
 {
   //Select the target register based on word address
   switch(address & 0x00000FFC)


### PR DESCRIPTION
`uint_8`, `uint_16` and `uint32` are portable standard C types available via `#include <stdint.h>`. The `u_int_nn` types are not portable and seem to be a linux oddity.